### PR TITLE
Feature/feedback client psi flavor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -171,7 +171,7 @@ android {
             applicationId "org.dhis2.psi"
             dimension "default"
             versionCode 7
-            versionName "2.1.1"
+            versionName "2.1.1-psi-fork-1"
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -171,7 +171,7 @@ android {
             applicationId "org.dhis2.psi"
             dimension "default"
             versionCode 7
-            versionName "2.0.0"
+            versionName "2.1.1"
         }
     }
 

--- a/app/src/dhis/java/org.dhis2.utils/CustomizableConstants.kt
+++ b/app/src/dhis/java/org.dhis2.utils/CustomizableConstants.kt
@@ -1,0 +1,3 @@
+package org.dhis2.utils
+
+const val DEFAULT_URL: String = ""

--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2020-06-01 11:04","gitSha":"96e5387ab"}
+{"buildTime":"2020-06-08 11:59","gitSha":"aec13e0a5"}

--- a/app/src/main/java/org/dhis2/usescases/login/LoginPresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/login/LoginPresenter.kt
@@ -26,6 +26,7 @@ import org.dhis2.utils.Constants.SERVER
 import org.dhis2.utils.Constants.USER
 import org.dhis2.utils.Constants.USER_ASKED_CRASHLYTICS
 import org.dhis2.utils.Constants.USER_TEST_ANDROID
+import org.dhis2.utils.DEFAULT_URL
 import org.dhis2.utils.TestingCredential
 import org.dhis2.utils.analytics.ACCOUNT_RECOVERY
 import org.dhis2.utils.analytics.AnalyticsHelper
@@ -78,7 +79,11 @@ class LoginPresenter(
                                     view.setUrl(serverUrl)
                                     view.setUser(user)
                                 } else {
-                                    view.setUrl(view.getDefaultServerProtocol())
+                                    val defaultUrl = {
+                                        if (DEFAULT_URL.isEmpty()) view.getDefaultServerProtocol() else DEFAULT_URL
+                                    }
+
+                                    view.setUrl(defaultUrl())
                                 }
                             }
                         },
@@ -236,7 +241,7 @@ class LoginPresenter(
     fun handleResponse(userResponse: Response<*>, userName: String, server: String) {
         view.showLoginProgress(false)
         if (userResponse.isSuccessful) {
-            if(view.isNetworkAvailable()) {
+            if (view.isNetworkAvailable()) {
                 preferenceProvider.setValue(Preference.INITIAL_SYNC_DONE, false)
             }
 
@@ -282,7 +287,7 @@ class LoginPresenter(
 
     fun areSameCredentials(serverUrl: String, userName: String, pass: String): Boolean {
         return preferenceProvider.areCredentialsSet() &&
-                preferenceProvider.areSameCredentials(serverUrl, userName, pass)
+            preferenceProvider.areSameCredentials(serverUrl, userName, pass)
     }
 
     fun saveUserCredentials(serverUrl: String, userName: String, pass: String) {

--- a/app/src/psi/java/org.dhis2.utils/CustomizableConstants.kt
+++ b/app/src/psi/java/org.dhis2.utils/CustomizableConstants.kt
@@ -1,0 +1,3 @@
+package org.dhis2.utils
+
+const val DEFAULT_URL: String = "https://data.psi-mis.org"

--- a/app/src/widp/java/org.dhis2.utils/CustomizableConstants.kt
+++ b/app/src/widp/java/org.dhis2.utils/CustomizableConstants.kt
@@ -1,0 +1,3 @@
+package org.dhis2.utils
+
+const val DEFAULT_URL: String = ""


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #11    
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: feature/feedback_client_psi_flavor Target: develop-uio
**dhis2-android-SDK**: 
       Origin: f3e89e26ae99e61eaa5b20c6c48d568e9e46e10a
**dhis2-rule-engine**: 
       Origin: 10af7eb0af6313f3c433c4c4fa3e88e747f57d0a
### :tophat: What is the goal?

- pre-populated URL https://data.psi-mis.org
- about version should be 2.1.1 
- verify screen sharing is not allowed in release mode

### :memo: How is it being implemented?

- I have created constants by flavor with DEFAULT_URL
- I have modified version name for psi flavor
- I have reviewed in a release apk that to take screenshot screen is not allowed

### :boom: How can it be tested?

**Use case 1:** - the default login url should be https://data.psi-mis.org
**Use case 2:** - in the about screen the version should be 2.1.1
**Use case 3:** - in the release apk to take screenshot should not be allowed

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-

