### PR TITLE
Feature/changes in program stage attribute code and replace pattern logic

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -311,7 +311,7 @@ dependencies {
 
     // Kujaku dependencies
 //    implementation 'io.ona.kujaku:library:0.7.7'
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:8.3.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.2.0'
     implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-markerview-v8:0.3.0'
     implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.8.0'
 

--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2020-07-17 18:27","gitSha":"ceaa6f433"}
+{"buildTime":"2020-08-13 13:58","gitSha":"c8d8a7e9a"}

--- a/app/src/main/java/org/dhis2/utils/extension/AnyExtension.kt
+++ b/app/src/main/java/org/dhis2/utils/extension/AnyExtension.kt
@@ -1,0 +1,23 @@
+package org.dhis2.utils.extension
+
+/**
+ * Invokes method from a object using reflection
+ */
+fun <T : Any> T.invoke(method: String): Any {
+    return javaClass.invoke(this, method);
+}
+
+/**
+ * invokes a class method by looking for it in its base classes if not exist
+ */
+private fun <T> Class<T>.invoke(obj: T, method: String): Any {
+    return try {
+        this.getMethod(method).invoke(obj)
+    } catch (e: IllegalAccessException) {
+        if (this.superclass != null) {
+            superclass.invoke(obj, method)
+        } else {
+            throw e
+        }
+    }
+}

--- a/app/src/test/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCapturePresenterTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCapturePresenterTest.kt
@@ -20,6 +20,7 @@ class EventCapturePresenterTest {
     private lateinit var presenter: EventCapturePresenterImpl
     private val view: EventCaptureContract.View = mock()
     private val eventUid = "eventUid"
+    private val programUid = "programUid"
     private val eventRepository: EventCaptureContract.EventCaptureRepository = mock()
     private val rulesUtilProvider: RulesUtilsProvider = mock()
     private val valueStore: ValueStore = mock()
@@ -30,6 +31,7 @@ class EventCapturePresenterTest {
         presenter = EventCapturePresenterImpl(
             view,
             eventUid,
+            programUid,
             eventRepository,
             rulesUtilProvider,
             valueStore,

--- a/app/src/testPsi/java/org/dhis2/usecases/eventsWithoutRegistration/eventCapture/EventCaptureRepositoryFunctionsTest.kt
+++ b/app/src/testPsi/java/org/dhis2/usecases/eventsWithoutRegistration/eventCapture/EventCaptureRepositoryFunctionsTest.kt
@@ -1,46 +1,94 @@
 package org.dhis2.usecases.eventsWithoutRegistration.eventCapture
 
+import org.dhis2.utils.extension.invoke
+import org.hisp.dhis.android.core.option.Option
 import org.junit.Assert
 import org.junit.Test
 
 class EventCaptureRepositoryFunctionsTest {
-    private val names = mapOf("1" to "name1", "2" to "name2", "3" to "name3")
-    private val getDataElementDisplayName = { uid: String -> names[uid] ?: "" }
+    private val selectedOption = Option.builder()
+        .uid("2")
+        .code("code2")
+        .name("name2")
+        .displayName("displayName2").build()
+
+    private val names = mapOf(
+        "DE_UID_1" to "value1",
+        "DE_UID_2" to selectedOption,
+        "DE_UID_3" to "value3"
+    )
+
+    private val getDataElementValue = { uid: String, prop: String ->
+        val value = names[uid] ?: ""
+
+        if (value is Option) {
+            value.invoke(prop) as String
+        } else {
+            value as String
+        }
+    }
 
     @Test
-    fun `Should return expected program stage name replacing data element uid tokens for one data element`() {
-        val attValue = "Name: {{1}}"
+    fun `should replace data element uid token with displayName of selected option by default if DE is of option set type`() {
+        val attValue = "Name2: {{DE_UID_2}}"
 
-        val result = getProgramStageNameByAttributeValue(attValue, getDataElementDisplayName)
+        val result = getProgramStageNameByAttributeValue(attValue, getDataElementValue)
 
-        Assert.assertEquals("Name: name1", result)
+        Assert.assertEquals("Name2: displayName2", result)
+    }
+
+    @Test
+    fun `should replace data element uid token with name of selected option if DE is of option set type`() {
+        val attValue = "Name2: {{DE_UID_2.name}}"
+
+        val result = getProgramStageNameByAttributeValue(attValue, getDataElementValue)
+
+        Assert.assertEquals("Name2: name2", result)
+    }
+
+    @Test
+    fun `should replace data element uid token with code of selected option if DE is of option set type`() {
+        val attValue = "Name2: {{DE_UID_2.code}}"
+
+        val result = getProgramStageNameByAttributeValue(attValue, getDataElementValue)
+
+        Assert.assertEquals("Name2: code2", result)
+    }
+
+
+    @Test
+    fun `should replace data element uid token with its value`() {
+        val attValue = "Name: {{DE_UID_1}}"
+
+        val result = getProgramStageNameByAttributeValue(attValue, getDataElementValue)
+
+        Assert.assertEquals("Name: value1", result)
     }
 
     @Test
     fun `Should return expected program stage name replacing data element uid tokens for two data elements`() {
-        val attValue = "Name: {{1}} Name2: {{2}}"
+        val attValue = "Name: {{DE_UID_1}} Name3: {{DE_UID_3}}"
 
-        val result = getProgramStageNameByAttributeValue(attValue, getDataElementDisplayName)
+        val result = getProgramStageNameByAttributeValue(attValue, getDataElementValue)
 
-        Assert.assertEquals("Name: name1 Name2: name2", result)
+        Assert.assertEquals("Name: value1 Name3: value3", result)
     }
 
     @Test
     fun `Should return expected program stage name replacing data element uid tokens for three data elements`() {
-        val attValue = "Name: {{1}} Name2: {{2}} Name3: {{3}}"
+        val attValue = "Name: {{DE_UID_1}} Name2: {{DE_UID_2}} Name3: {{DE_UID_3}}"
 
-        val result = getProgramStageNameByAttributeValue(attValue, getDataElementDisplayName)
+        val result = getProgramStageNameByAttributeValue(attValue, getDataElementValue)
 
-        Assert.assertEquals("Name: name1 Name2: name2 Name3: name3", result)
+        Assert.assertEquals("Name: value1 Name2: displayName2 Name3: value3", result)
     }
 
     @Test
     fun `Should return expected program stage name replacing data element uid tokens for two equal data elements`() {
-        val attValue = "Name: {{1}} Name2: {{1}}"
+        val attValue = "Name: {{DE_UID_1}} Name2: {{DE_UID_2}}"
 
-        val result = getProgramStageNameByAttributeValue(attValue, getDataElementDisplayName)
+        val result = getProgramStageNameByAttributeValue(attValue, getDataElementValue)
 
-        Assert.assertEquals("Name: name1 Name2: name1", result)
+        Assert.assertEquals("Name: value1 Name2: displayName2", result)
     }
-
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #25  
* **Related pull-requests:** 

###   :gear: branches 
**app**: 
       Origin: feature/changes_in_program_stage_attribute_code_and_replace_pattern_logic Target: develop-uio
**dhis2-android-SDK**: 
       Origin: develop-uio
**dhis2-rule-engine**: 
       Origin: master
### :tophat: What is the goal?

The goal is to change the code of the PatternHeader attribute to PatternTitle and to extend the functionality to allow to be able to indicate the property of a selected option when the data element type is of option set type. 

### :memo: How is it being implemented?

- I have change hardcode code for the attribute from PatternHeader to PatternTitle
- I have created extension functions in Kotlin to invoke dynamically the property. If this property does not exist then displayName is shown as before.
- I have fixed a crash to execute the app in an emulator and in a device upgrading the library 
java.lang.UnsatisfiedLinkError: No implementation found for void com.mapbox.mapboxsdk.net.NativeConnectivityListener.initialize()

### :boom: How can it be tested?

**Use case 1:** - Configure the attribute {{UID}} in a program stage and display name should be shown as the title of the events for this program stage.
**Use case 2:** - Configure the attribute {{UID.name}} in a program stage and name should be shown as the title of the events for this program stage.
**Use case 3:** - Configure the attribute {{UID.code}} in a program stage and code should be shown as the title of the events for this program stage.
**Use case 4:** - Configure the attribute with error {{UID.code.name}} in a program stage and display name should be shown as the title of the events for this program stage ignoring the property.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-

