### PR TITLE
If items inside token is distinct of 2 show display name

### DIFF
--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2020-08-13 13:58","gitSha":"c8d8a7e9a"}
+{"buildTime":"2020-08-17 10:37","gitSha":"97a4f8b59"}

--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2020-08-17 10:37","gitSha":"97a4f8b59"}
+{"buildTime":"2020-08-17 11:17","gitSha":"bcc96daab"}

--- a/app/src/psi/java/org/dhis2/usecases/eventsWithoutRegistration/eventCapture/eventCaptureRepositoryFunctions.kt
+++ b/app/src/psi/java/org/dhis2/usecases/eventsWithoutRegistration/eventCapture/eventCaptureRepositoryFunctions.kt
@@ -2,10 +2,7 @@ package org.dhis2.usecases.eventsWithoutRegistration.eventCapture
 
 import org.dhis2.Bindings.valueByPropName
 import org.hisp.dhis.android.core.D2
-import timber.log.Timber
 import java.util.HashMap
-
-class TitlePatternFormatException(message: String?) : Exception(message) {}
 
 fun getProgramStageName(d2: D2, eventUid: String): String {
     val event = d2.eventModule().events().uid(eventUid).blockingGet()

--- a/app/src/psi/java/org/dhis2/usecases/eventsWithoutRegistration/eventCapture/eventCaptureRepositoryFunctions.kt
+++ b/app/src/psi/java/org/dhis2/usecases/eventsWithoutRegistration/eventCapture/eventCaptureRepositoryFunctions.kt
@@ -78,15 +78,12 @@ fun getProgramStageNameByAttributeValue(
         if (!dataElementsMap.containsKey(tokenWithBrackets)) {
             val tokenItems = tokenWithBrackets.substring(2, it.value.length - 2).split(".")
 
-            if (tokenItems.size == 1) {
-                dataElementsMap[tokenWithBrackets] =
-                    getDataElementValue(tokenItems[0], "displayName")
-            } else if (tokenItems.size == 2) {
+            if (tokenItems.size == 2) {
                 dataElementsMap[tokenWithBrackets] =
                     getDataElementValue(tokenItems[0], tokenItems[1])
             } else {
-                Timber.w("Invalid TitlePattern ")
-                throw TitlePatternFormatException("Invalid TitlePattern")
+                dataElementsMap[tokenWithBrackets] =
+                    getDataElementValue(tokenItems[0], "displayName")
             }
         }
     }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #27   
* **Related pull-requests:** 

###   :gear: branches 
**app**: 
       Origin: fix/with_correct_uid_in_pattern_and_worng_num_props_show_display_nam Target: develop-uio
**dhis2-android-SDK**: 
       Origin: develop-uio
**dhis2-rule-engine**: 
       Origin: android_2.0.1
### :tophat: What is the goal?

The goal is to unify prop part in the pattern, and if the pattern contains more of a property after DE uid then show the display name.

### :memo: How is it being implemented?

- I have modified the logic to select the property to show

### :boom: How can it be tested?

**Use case 1:** - Configure the attribute {{UID}} in a program stage and display name should be shown as the title of the events for this program stage.
**Use case 2:** - Configure the attribute {{UID.name}} in a program stage and name should be shown as the title of the events for this program stage.
**Use case 3:** - Configure the attribute {{UID.code}} in a program stage and code should be shown as the title of the events for this program stage.
**Use case 4:** - Configure the attribute with error {{UID.code.name}} in a program stage and display name should be shown as the title of the events for this program stage ignoring the property.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-
