### PR TITLE
Feature/feedback multilingual support

### DIFF
--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2021-02-01 16:24","gitSha":"d78cb2e90"}
+{"buildTime":"2021-02-02 07:55","gitSha":"f88d0c585"}

--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2021-02-02 07:55","gitSha":"f88d0c585"}
+{"buildTime":"2021-02-02 13:00","gitSha":"5bf1bb22a"}

--- a/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/Entities.kt
+++ b/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/Entities.kt
@@ -61,3 +61,5 @@ data class Value(
 )
 
 data class Event(val uid: String, val name: String, val values: List<Value> = listOf())
+
+data class MultilingualFeedback (val text:String, val locale:String)

--- a/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/FeedbackContentFragment.kt
+++ b/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/FeedbackContentFragment.kt
@@ -33,7 +33,7 @@ class FeedbackContentFragment : FragmentGlobalAbstract(),
 
         if (((context.applicationContext) as App).dashboardComponent() != null) {
             ((context.applicationContext) as App).dashboardComponent()!!
-                .plus(FeedbackModule(activity.programUid, activity.teiUid, activity.enrollmentUid))
+                .plus(FeedbackModule(activity.programUid, activity.teiUid, activity.enrollmentUid,context))
                 .inject(this)
         }
     }

--- a/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/FeedbackFragment.kt
+++ b/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/FeedbackFragment.kt
@@ -35,7 +35,7 @@ class FeedbackFragment : FragmentGlobalAbstract(), FeedbackPresenter.FeedbackVie
 
         if (((context.applicationContext) as App).dashboardComponent() != null) {
             ((context.applicationContext) as App).dashboardComponent()!!
-                .plus(FeedbackModule(activity.programUid,activity.teiUid,activity.enrollmentUid))
+                .plus(FeedbackModule(activity.programUid, activity.teiUid, activity.enrollmentUid))
                 .inject(this)
         }
     }
@@ -69,18 +69,25 @@ class FeedbackFragment : FragmentGlobalAbstract(), FeedbackPresenter.FeedbackVie
             binding.feedbackPager
         ) { tab: TabLayout.Tab, position: Int ->
 
-            if (programType == ProgramType.RDQA) {
-                tab.text = rdqaTabTitles[position]
+            val tabKey = if (programType == ProgramType.RDQA) {
+                rdqaTabTitles[position]
             } else {
-                tab.text = hnqisTabTitles[position]
+                hnqisTabTitles[position]
             }
+
+            tab.text = getString(resources.getIdentifier(tabKey, "string", context?.packageName))
 
         }.attach()
     }
 
     companion object {
-        val rdqaTabTitles = listOf("By indicator", "By technical area")
-        val hnqisTabTitles = listOf("All", "Critical", "Non Critical")
+        val rdqaTabTitles =
+            listOf("feedback_tab_rdqa_by_indicator", "feedback_tab_rdqa_by_technical_area")
+        val hnqisTabTitles = listOf(
+            "feedback_tab_hnqis_all",
+            "feedback_tab_hnqis_critical",
+            "feedback_tab_hnqis_non_critical"
+        )
     }
 
     override fun render(state: FeedbackState) {

--- a/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/FeedbackFragment.kt
+++ b/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/FeedbackFragment.kt
@@ -35,7 +35,7 @@ class FeedbackFragment : FragmentGlobalAbstract(), FeedbackPresenter.FeedbackVie
 
         if (((context.applicationContext) as App).dashboardComponent() != null) {
             ((context.applicationContext) as App).dashboardComponent()!!
-                .plus(FeedbackModule(activity.programUid, activity.teiUid, activity.enrollmentUid))
+                .plus(FeedbackModule(activity.programUid, activity.teiUid, activity.enrollmentUid, context))
                 .inject(this)
         }
     }

--- a/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/FeedbackModule.kt
+++ b/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/FeedbackModule.kt
@@ -28,7 +28,8 @@ import org.hisp.dhis.rules.RuleExpressionEvaluator
 class FeedbackModule(
     private val programUid: String,
     private val teiUid: String,
-    private val enrollmentUid: String
+    private val enrollmentUid: String,
+    private val context: Context
 ) {
     @Provides
     @PerFragment
@@ -77,7 +78,7 @@ class FeedbackModule(
     @Provides
     @PerFragment
     fun provideValuesRepository(d2: D2): ValuesRepository {
-        return ValuesD2Repository(d2)
+        return ValuesD2Repository(d2, context)
     }
 
     @Provides

--- a/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/ValuesD2Repository.kt
+++ b/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/ValuesD2Repository.kt
@@ -1,13 +1,21 @@
 package org.dhis2.usescases.teiDashboard.dashboardsfragments.feedback
 
+import android.content.Context
+import android.os.Build
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import org.dhis2.Bindings.userFriendlyValue
+import org.dhis2.R
+import org.dhis2.utils.JsonCheckResult
+import org.dhis2.utils.JsonChecker
 import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.attribute.Attribute
 import org.hisp.dhis.android.core.attribute.AttributeValue
 import org.hisp.dhis.android.core.dataelement.DataElement
 import org.hisp.dhis.android.core.legendset.Legend
+import java.util.Locale
 
-class ValuesD2Repository(private val d2: D2) : ValuesRepository {
+class ValuesD2Repository(private val d2: D2, private val context: Context) : ValuesRepository {
     val dataElements: List<DataElement> = d2.dataElementModule().dataElements().get().blockingGet()
 
     override fun getByEvent(eventUid: String): List<Value> {
@@ -32,9 +40,11 @@ class ValuesD2Repository(private val d2: D2) : ValuesRepository {
                 val assignedLegend = getAssignedLegend(teiValue.value()!!, teiValue.dataElement()!!)
                 val deAttributeValues = getDataElementAttributeValues(teiValue.dataElement()!!)
 
-                val deFeedbackHelp = deAttributeValues.firstOrNull {
+                val deFeedbackHelpRaw = deAttributeValues.firstOrNull {
                     it.attribute().code() == feedbackTextAttributeCode
                 }
+
+                val deFeedbackHelp = parseFeedbackHelp(deFeedbackHelpRaw, dataElement.uid())
 
                 val deFeedbackOrder = deAttributeValues.firstOrNull {
                     it.attribute().code() == feedbackOrderAttributeCode
@@ -49,12 +59,44 @@ class ValuesD2Repository(private val d2: D2) : ValuesRepository {
                     teiValue.userFriendlyValue(d2)!!,
                     FeedbackOrder(deFeedbackOrder!!.value()),
                     assignedLegend?.color(),
-                    deFeedbackHelp?.value(),
+                    deFeedbackHelp,
                     assignedLegend?.name()?.split("_")?.last() != failLegendSuffix,
                     dataElementsWithMandatory.contains(teiValue.dataElement()!!),
                     eventUid
                 )
             }
+    }
+
+    private fun parseFeedbackHelp(feedbackHelpRaw: AttributeValue?, dataElement: String): String? {
+        if (feedbackHelpRaw == null) return null
+
+        val malformedJsonError = context.getString(R.string.feedback_malformed_error, dataElement)
+
+        when (JsonChecker().check(feedbackHelpRaw.value())) {
+            is JsonCheckResult.Json -> {
+                val gson = Gson()
+                val language = getCurrentLocale()?.language
+
+                try {
+                    val type = object : TypeToken<List<MultilingualFeedback>>() {}.type
+                    val multilingualFeedbackList =
+                        gson.fromJson<List<MultilingualFeedback>>(feedbackHelpRaw.value(), type)
+
+                    return if (multilingualFeedbackList.isEmpty()) {
+                        null
+                    } else {
+                        val feedbackCurrentLocale =
+                            multilingualFeedbackList.firstOrNull { f -> f.locale == language }
+
+                        feedbackCurrentLocale?.text ?: multilingualFeedbackList[0].text
+                    }
+                } catch (e: Exception) {
+                    return malformedJsonError
+                }
+            }
+            is JsonCheckResult.MalformedJson -> return malformedJsonError
+            is JsonCheckResult.Text -> return feedbackHelpRaw.value()
+        }
     }
 
     private fun getDataElementsWithFeedbackOrder(
@@ -158,5 +200,13 @@ class ValuesD2Repository(private val d2: D2) : ValuesRepository {
         }
 
         return attributes
+    }
+
+    private fun getCurrentLocale(): Locale? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            context.resources.configuration.locales[0]
+        } else {
+            context.resources.configuration.locale
+        }
     }
 }

--- a/app/src/psi/java/org/dhis2/utils/JsonChecker.kt
+++ b/app/src/psi/java/org/dhis2/utils/JsonChecker.kt
@@ -1,0 +1,31 @@
+package org.dhis2.utils
+
+import com.google.gson.JsonParser
+import java.lang.Exception
+
+sealed class JsonCheckResult {
+    object Json : JsonCheckResult()
+    object MalformedJson : JsonCheckResult()
+    object Text : JsonCheckResult()
+}
+
+class JsonChecker {
+    fun check(json: String): JsonCheckResult {
+
+        return if (isAJson(json)) {
+            try {
+                JsonParser.parseString(json)
+
+                JsonCheckResult.Json
+            } catch (e: Exception) {
+                JsonCheckResult.MalformedJson
+            }
+        } else {
+            JsonCheckResult.Text
+        }
+    }
+
+    private fun isAJson(json: String): Boolean {
+        return json.indexOfAny(charArrayOf('[', ']', '{', '}', '"')) >= 0
+    }
+}

--- a/app/src/psi/java/org/dhis2/utils/JsonChecker.kt
+++ b/app/src/psi/java/org/dhis2/utils/JsonChecker.kt
@@ -26,6 +26,6 @@ class JsonChecker {
     }
 
     private fun isAJson(json: String): Boolean {
-        return json.indexOfAny(charArrayOf('[', ']', '{', '}', '"')) >= 0
+        return json.indexOfAny(charArrayOf('{', '}')) >= 0
     }
 }

--- a/app/src/psi/res/layout/item_feedback.xml
+++ b/app/src/psi/res/layout/item_feedback.xml
@@ -27,7 +27,9 @@
         app:layout_constraintWidth_percent="0.25"
         android:layout_marginHorizontal="16dp"
         android:layout_marginVertical="8dp"
-        android:gravity="end">
+        android:gravity="end"
+        android:textIsSelectable="true"
+        android:textColorHighlight="?colorPrimary">
         <TextView
             android:id="@+id/value"
             android:layout_width="wrap_content"
@@ -35,7 +37,9 @@
             android:layout_gravity="end"
             android:padding="8dp"
             android:textAlignment="textEnd"
-            android:text="No en lo absoluto"/>
+            android:text="No en lo absoluto"
+            android:textIsSelectable="true"
+            android:textColorHighlight="?colorPrimary"/>
     </RelativeLayout>
 
 

--- a/app/src/psi/res/layout/item_help_feedback.xml
+++ b/app/src/psi/res/layout/item_help_feedback.xml
@@ -20,7 +20,9 @@
         app:layout_constraintEnd_toStartOf="@+id/arrow"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintWidth_percent="0.9" />
+        app:layout_constraintWidth_percent="0.9"
+        android:textIsSelectable="true"
+        android:textColorHighlight="?colorPrimary"/>
 
 
     <androidx.appcompat.widget.AppCompatImageView

--- a/app/src/psi/res/values-ar/strings.xml
+++ b/app/src/psi/res/values-ar/strings.xml
@@ -8,4 +8,9 @@
     <string name="unexpected_error_message">لقد حدث خطأ غير متوقع. راجع التكوين الخاص بك أو اتصل بالمسؤول</string>
     <string name="feedback_show_only_failed">إظهار فشل فقط</string>
     <string name="feedback_url">"شاهد الملاحظات الكاملة على:"</string>
+    <string name="feedback_tab_rdqa_by_indicator">"By indicator"</string>
+    <string name="feedback_tab_rdqa_by_technical_area">"By technical area"</string>
+    <string name="feedback_tab_hnqis_all">"All"</string>
+    <string name="feedback_tab_hnqis_critical">"Critical"</string>
+    <string name="feedback_tab_hnqis_non_critical">"Non Critical"</string>
 </resources>

--- a/app/src/psi/res/values-ar/strings.xml
+++ b/app/src/psi/res/values-ar/strings.xml
@@ -8,9 +8,10 @@
     <string name="unexpected_error_message">لقد حدث خطأ غير متوقع. راجع التكوين الخاص بك أو اتصل بالمسؤول</string>
     <string name="feedback_show_only_failed">إظهار فشل فقط</string>
     <string name="feedback_url">"شاهد الملاحظات الكاملة على:"</string>
-    <string name="feedback_tab_rdqa_by_indicator">"By indicator"</string>
+    <string name="feedback_tab_rdqa_by_indicator">"حسب المؤشر"</string>
     <string name="feedback_tab_rdqa_by_technical_area">"By technical area"</string>
-    <string name="feedback_tab_hnqis_all">"All"</string>
-    <string name="feedback_tab_hnqis_critical">"Critical"</string>
-    <string name="feedback_tab_hnqis_non_critical">"Non Critical"</string>
+    <string name="feedback_tab_hnqis_all">"حسب المجال التقني"</string>
+    <string name="feedback_tab_hnqis_critical">"حرج"</string>
+    <string name="feedback_tab_hnqis_non_critical">"غير مهم"</string>
+    <string name="feedback_malformed_error">"**خطأ**: ملاحظات مشوهة لعنصر البيانات %s"</string>
 </resources>

--- a/app/src/psi/res/values-cs/strings.xml
+++ b/app/src/psi/res/values-cs/strings.xml
@@ -13,4 +13,5 @@
     <string name="feedback_tab_hnqis_all">"Všechno"</string>
     <string name="feedback_tab_hnqis_critical">"Kritický"</string>
     <string name="feedback_tab_hnqis_non_critical">"Není kritický"</string>
+    <string name="feedback_malformed_error">"**Chyba**: Poškozený JSON zpětné vazby pro datový prvek %s"</string>
 </resources>

--- a/app/src/psi/res/values-cs/strings.xml
+++ b/app/src/psi/res/values-cs/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">PSI dhis2</string>
+    <string name="logo_text">PSI dhis2</string>
+    <string name="logo_number"></string>
+    <string name="dashboard_feedback">Feedback</string>
+    <string name="program_type_configuration_error_message">V aktuálním programu došlo k chybě konfigurace typu programu. Zkontrolujte program na serveru a proveďte konfiguraci synchronizace</string>
+    <string name="unexpected_error_message">Došlo k neočekávané chybě. Zkontrolujte svou konfiguraci nebo kontaktujte svého správce</string>
+    <string name="feedback_show_only_failed">Zobrazit pouze se nezdařilo</string>
+    <string name="feedback_url">"Úplnou zpětnou vazbu naleznete na adrese:"</string>
+    <string name="feedback_tab_rdqa_by_indicator">"Podle indikátoru"</string>
+    <string name="feedback_tab_rdqa_by_technical_area">"Podle technické oblasti"</string>
+    <string name="feedback_tab_hnqis_all">"Všechno"</string>
+    <string name="feedback_tab_hnqis_critical">"Kritický"</string>
+    <string name="feedback_tab_hnqis_non_critical">"Není kritický"</string>
+</resources>

--- a/app/src/psi/res/values-es/strings.xml
+++ b/app/src/psi/res/values-es/strings.xml
@@ -8,4 +8,9 @@
     <string name="unexpected_error_message">Ha ocurrido un error inesperado. Revise su configuración o contacte con su administrador</string>
     <string name="feedback_show_only_failed">Mostrar solo erroneas</string>
     <string name="feedback_url">"Ver comentarios completos en:"</string>
+    <string name="feedback_tab_rdqa_by_indicator">"Por indicador"</string>
+    <string name="feedback_tab_rdqa_by_technical_area">"Por área técnica"</string>
+    <string name="feedback_tab_hnqis_all">"Todas"</string>
+    <string name="feedback_tab_hnqis_critical">"Críticas"</string>
+    <string name="feedback_tab_hnqis_non_critical">"No Críticas"</string>
 </resources>

--- a/app/src/psi/res/values-es/strings.xml
+++ b/app/src/psi/res/values-es/strings.xml
@@ -13,4 +13,5 @@
     <string name="feedback_tab_hnqis_all">"Todas"</string>
     <string name="feedback_tab_hnqis_critical">"Críticas"</string>
     <string name="feedback_tab_hnqis_non_critical">"No Críticas"</string>
+    <string name="feedback_malformed_error">"**Error**: json de retroalimentación con formato incorrecto para el elemento de datos %s"</string>
 </resources>

--- a/app/src/psi/res/values-fr/strings.xml
+++ b/app/src/psi/res/values-fr/strings.xml
@@ -13,4 +13,5 @@
     <string name="feedback_tab_hnqis_all">"Toute"</string>
     <string name="feedback_tab_hnqis_critical">"Critique"</string>
     <string name="feedback_tab_hnqis_non_critical">"Pas critique"</string>
+    <string name="feedback_malformed_error">"**Erreur**: json de retour incorrect pour l'élément de données %s"</string>
 </resources>

--- a/app/src/psi/res/values-fr/strings.xml
+++ b/app/src/psi/res/values-fr/strings.xml
@@ -8,4 +8,9 @@
     <string name="unexpected_error_message">"Une erreur imprévue s'est produite. Vérifiez votre configuration ou contactez votre administrateur"</string>
     <string name="feedback_show_only_failed">Afficher seulement échoué</string>
     <string name="feedback_url">"Voir les commentaires complets sur:"</string>
+    <string name="feedback_tab_rdqa_by_indicator">"Par indicateur"</string>
+    <string name="feedback_tab_rdqa_by_technical_area">"Par domaine technique"</string>
+    <string name="feedback_tab_hnqis_all">"Toute"</string>
+    <string name="feedback_tab_hnqis_critical">"Critique"</string>
+    <string name="feedback_tab_hnqis_non_critical">"Pas critique"</string>
 </resources>

--- a/app/src/psi/res/values-id/strings.xml
+++ b/app/src/psi/res/values-id/strings.xml
@@ -13,4 +13,5 @@
     <string name="feedback_tab_hnqis_all">"Semua"</string>
     <string name="feedback_tab_hnqis_critical">"Kritis"</string>
     <string name="feedback_tab_hnqis_non_critical">"Tidak Kritis"</string>
+    <string name="feedback_malformed_error">"**Error**: Masukan salah format untuk elemen data %s"</string>
 </resources>

--- a/app/src/psi/res/values-id/strings.xml
+++ b/app/src/psi/res/values-id/strings.xml
@@ -8,4 +8,9 @@
     <string name="unexpected_error_message">erjadi sebuah kesalahan yang tidak diharapkan. Tinjau konfigurasi atau kontak Anda dengan administrator Anda</string>
     <string name="feedback_show_only_failed">Pertunjukan hanya gagal</string>
     <string name="feedback_url">"Lihat masukan lengkapnya di:"</string>
+    <string name="feedback_tab_rdqa_by_indicator">"Dengan indikator"</string>
+    <string name="feedback_tab_rdqa_by_technical_area">"Berdasarkan bidang teknis"</string>
+    <string name="feedback_tab_hnqis_all">"Semua"</string>
+    <string name="feedback_tab_hnqis_critical">"Kritis"</string>
+    <string name="feedback_tab_hnqis_non_critical">"Tidak Kritis"</string>
 </resources>

--- a/app/src/psi/res/values-km/strings.xml
+++ b/app/src/psi/res/values-km/strings.xml
@@ -13,4 +13,5 @@
     <string name="feedback_tab_hnqis_all">"ទាំងអស់"</string>
     <string name="feedback_tab_hnqis_critical">"សំខាន់"</string>
     <string name="feedback_tab_hnqis_non_critical">"មិនសំខាន់"</string>
+    <string name="feedback_malformed_error">"**កំហុស**៖ មតិប្រតិកម្មមិនត្រឹមត្រូវសម្រាប់ធាតុទិន្នន័យ %s"</string>
 </resources>

--- a/app/src/psi/res/values-km/strings.xml
+++ b/app/src/psi/res/values-km/strings.xml
@@ -8,4 +8,9 @@
     <string name="unexpected_error_message">កំហុស​ដែល​មិន​រំពឹង​ទុក​បាន​កើត​ឡើង​។ ពិនិត្យមើលការកំណត់រចនាសម្ព័ន្ធឬទំនាក់ទំនងរបស់អ្នកជាមួយអ្នកគ្រប់គ្រងរបស់អ្នក</string>
     <string name="feedback_show_only_failed">បង្ហាញតែបរាជ័យ</string>
     <string name="feedback_url">"មើលមតិប្រតិកម្មពេញលេញនៅ៖"</string>
+    <string name="feedback_tab_rdqa_by_indicator">"ដោយសូចនាករ"</string>
+    <string name="feedback_tab_rdqa_by_technical_area">"តាមតំបន់បច្ចេកទេស"</string>
+    <string name="feedback_tab_hnqis_all">"ទាំងអស់"</string>
+    <string name="feedback_tab_hnqis_critical">"សំខាន់"</string>
+    <string name="feedback_tab_hnqis_non_critical">"មិនសំខាន់"</string>
 </resources>

--- a/app/src/psi/res/values-lo/strings.xml
+++ b/app/src/psi/res/values-lo/strings.xml
@@ -13,4 +13,5 @@
     <string name="feedback_tab_hnqis_all">"ທັງ ໝົດ"</string>
     <string name="feedback_tab_hnqis_critical">"ທີ່ ສຳ ຄັນ"</string>
     <string name="feedback_tab_hnqis_non_critical">"ບໍ່ ສຳ ຄັນ"</string>
+    <string name="feedback_malformed_error">"**ຂໍ້ຜິດພາດ**: ຂໍ້ຄິດເຫັນທີ່ບໍ່ຖືກຕ້ອງ ສຳ ລັບອົງປະກອບຂໍ້ມູນ %s"</string>
 </resources>

--- a/app/src/psi/res/values-lo/strings.xml
+++ b/app/src/psi/res/values-lo/strings.xml
@@ -8,4 +8,9 @@
     <string name="unexpected_error_message">ຂໍ້ຜິດພາດທີ່ບໍ່ຄາດຄິດໄດ້ເກີດຂື້ນ. ກວດສອບການຕັ້ງຄ່າຫລືຕິດຕໍ່ກັບຜູ້ເບິ່ງແຍງລະບົບຂອງທ່ານ</string>
     <string name="feedback_show_only_failed">ສະແດງບໍ່ພຽງແຕ່ລົ້ມເຫລວ</string>
     <string name="feedback_url">"ເບິ່ງ ຄຳ ຕິຊົມຢ່າງເຕັມທີ່:"</string>
+    <string name="feedback_tab_rdqa_by_indicator">"ໂດຍຕົວຊີ້ວັດ"</string>
+    <string name="feedback_tab_rdqa_by_technical_area">"ໂດຍພື້ນທີ່ດ້ານເຕັກນິກ"</string>
+    <string name="feedback_tab_hnqis_all">"ທັງ ໝົດ"</string>
+    <string name="feedback_tab_hnqis_critical">"ທີ່ ສຳ ຄັນ"</string>
+    <string name="feedback_tab_hnqis_non_critical">"ບໍ່ ສຳ ຄັນ"</string>
 </resources>

--- a/app/src/psi/res/values-nb/strings.xml
+++ b/app/src/psi/res/values-nb/strings.xml
@@ -13,4 +13,5 @@
     <string name="feedback_tab_hnqis_all">"Alle"</string>
     <string name="feedback_tab_hnqis_critical">"Kritisk"</string>
     <string name="feedback_tab_hnqis_non_critical">"Ikke kritisk"</string>
+    <string name="feedback_malformed_error">"**Feil**: Feilformet tilbakemelding for dataelementet %s"</string>
 </resources>

--- a/app/src/psi/res/values-nb/strings.xml
+++ b/app/src/psi/res/values-nb/strings.xml
@@ -8,4 +8,9 @@
     <string name="unexpected_error_message">En uventet feil har oppstått. Gå gjennom konfigurasjonen eller kontakt med administratoren din</string>
     <string name="feedback_show_only_failed">Visningen mislyktes</string>
     <string name="feedback_url">"Se full tilbakemelding på:"</string>
+    <string name="feedback_tab_rdqa_by_indicator">"Etter indikator"</string>
+    <string name="feedback_tab_rdqa_by_technical_area">"Etter teknisk område"</string>
+    <string name="feedback_tab_hnqis_all">"Alle"</string>
+    <string name="feedback_tab_hnqis_critical">"Kritisk"</string>
+    <string name="feedback_tab_hnqis_non_critical">"Ikke kritisk"</string>
 </resources>

--- a/app/src/psi/res/values-pt/strings.xml
+++ b/app/src/psi/res/values-pt/strings.xml
@@ -13,4 +13,5 @@
     <string name="feedback_tab_hnqis_all">"Todos"</string>
     <string name="feedback_tab_hnqis_critical">"Crítico"</string>
     <string name="feedback_tab_hnqis_non_critical">"Não Crítico"</string>
+    <string name="feedback_malformed_error">"**Erro**: feedback malformado para o elemento de dados %s"</string>
 </resources>

--- a/app/src/psi/res/values-pt/strings.xml
+++ b/app/src/psi/res/values-pt/strings.xml
@@ -8,4 +8,9 @@
     <string name="unexpected_error_message">Ocorreu um erro inesperado. Revise sua configuração ou entre em contato com seu administrador</string>
     <string name="feedback_show_only_failed">Mostrar apenas falhou</string>
     <string name="feedback_url">"Veja o feedback completo em:"</string>
+    <string name="feedback_tab_rdqa_by_indicator">"Por indicador"</string>
+    <string name="feedback_tab_rdqa_by_technical_area">"Por área técnicaa"</string>
+    <string name="feedback_tab_hnqis_all">"Todos"</string>
+    <string name="feedback_tab_hnqis_critical">"Crítico"</string>
+    <string name="feedback_tab_hnqis_non_critical">"Não Crítico"</string>
 </resources>

--- a/app/src/psi/res/values-ru/strings.xml
+++ b/app/src/psi/res/values-ru/strings.xml
@@ -13,4 +13,5 @@
     <string name="feedback_tab_hnqis_all">"Все"</string>
     <string name="feedback_tab_hnqis_critical">"Критический"</string>
     <string name="feedback_tab_hnqis_non_critical">"Не критично"</string>
+    <string name="feedback_malformed_error">"**Ошибка**: неверный ответ для элемента данных %s"</string>
 </resources>

--- a/app/src/psi/res/values-ru/strings.xml
+++ b/app/src/psi/res/values-ru/strings.xml
@@ -7,5 +7,10 @@
     <string name="program_type_configuration_error_message">текущей программе есть ошибка конфигурации типа программы. Пожалуйста, проверьте программу на сервере и выполните настройку синхронизации.</string>
     <string name="unexpected_error_message">Произошла непредвиденная ошибка. Проверьте конфигурацию или обратитесь к администратору</string>
     <string name="feedback_show_only_failed">Показать только не удалось</string>
-    <string name="feedback_url">"See full feedback at:"</string>
+    <string name="feedback_url">"См. Полный отзыв на:"</string>
+    <string name="feedback_tab_rdqa_by_indicator">"По показателю"</string>
+    <string name="feedback_tab_rdqa_by_technical_area">"По технической области"</string>
+    <string name="feedback_tab_hnqis_all">"Все"</string>
+    <string name="feedback_tab_hnqis_critical">"Критический"</string>
+    <string name="feedback_tab_hnqis_non_critical">"Не критично"</string>
 </resources>

--- a/app/src/psi/res/values-sv/strings.xml
+++ b/app/src/psi/res/values-sv/strings.xml
@@ -7,5 +7,10 @@
     <string name="program_type_configuration_error_message">Det finns ett konfigurationsfel för programtyp i det aktuella programmet. Kontrollera programmet på servern och utför synkroniseringskonfiguration</string>
     <string name="unexpected_error_message">Ett oväntat fel har uppstått. Granska din konfiguration eller kontakta din administratör</string>
     <string name="feedback_show_only_failed">Visningen misslyckades bara</string>
-    <string name="feedback_url">"См. Полный отзыв по адресу:"</string>
+    <string name="feedback_url">"Se fullständig feedback på:"</string>
+    <string name="feedback_tab_rdqa_by_indicator">"Efter indikator"</string>
+    <string name="feedback_tab_rdqa_by_technical_area">"Efter tekniskt område"</string>
+    <string name="feedback_tab_hnqis_all">"Allt"</string>
+    <string name="feedback_tab_hnqis_critical">"Kritisk"</string>
+    <string name="feedback_tab_hnqis_non_critical">"Inte kritiskt"</string>
 </resources>

--- a/app/src/psi/res/values-sv/strings.xml
+++ b/app/src/psi/res/values-sv/strings.xml
@@ -13,4 +13,5 @@
     <string name="feedback_tab_hnqis_all">"Allt"</string>
     <string name="feedback_tab_hnqis_critical">"Kritisk"</string>
     <string name="feedback_tab_hnqis_non_critical">"Inte kritiskt"</string>
+    <string name="feedback_malformed_error">"**Fel**: Felaktig feedback för dataelementet %s"</string>
 </resources>

--- a/app/src/psi/res/values-vi/strings.xml
+++ b/app/src/psi/res/values-vi/strings.xml
@@ -8,4 +8,9 @@
     <string name="unexpected_error_message">Một lỗi không mong muốn đã xảy ra. Xem lại cấu hình của bạn hoặc liên hệ với quản trị viên của bạn</string>
     <string name="feedback_show_only_failed">Chỉ hiển thị không thành công</string>
     <string name="feedback_url">"Xem phản hồi đầy đủ tại:"</string>
+    <string name="feedback_tab_rdqa_by_indicator">"Bvà chỉ báo"</string>
+    <string name="feedback_tab_rdqa_by_technical_area">"Bằng kỹ thuật làa"</string>
+    <string name="feedback_tab_hnqis_all">"Tất cả"</string>
+    <string name="feedback_tab_hnqis_critical">"Bạo kích"</string>
+    <string name="feedback_tab_hnqis_non_critical">"Không quan trọng"</string>
 </resources>

--- a/app/src/psi/res/values-vi/strings.xml
+++ b/app/src/psi/res/values-vi/strings.xml
@@ -13,4 +13,5 @@
     <string name="feedback_tab_hnqis_all">"Tất cả"</string>
     <string name="feedback_tab_hnqis_critical">"Bạo kích"</string>
     <string name="feedback_tab_hnqis_non_critical">"Không quan trọng"</string>
+    <string name="feedback_malformed_error">"**Lỗi**: Phản hồi không đúng định dạng cho Phần tử dữ liệu %s"</string>
 </resources>

--- a/app/src/psi/res/values-zh-rCN/strings.xml
+++ b/app/src/psi/res/values-zh-rCN/strings.xml
@@ -8,4 +8,9 @@
     <string name="unexpected_error_message">發生意外的錯誤。 查看您的配置或與管理員聯繫</string>
     <string name="feedback_show_only_failed">只顯示失敗</string>
     <string name="feedback_url">"查看完整的反饋意見："</string>
+    <string name="feedback_tab_rdqa_by_indicator">"按指標"</string>
+    <string name="feedback_tab_rdqa_by_technical_area">"按技術領域"</string>
+    <string name="feedback_tab_hnqis_all">"所有"</string>
+    <string name="feedback_tab_hnqis_critical">"危急"</string>
+    <string name="feedback_tab_hnqis_non_critical">"不重要"</string>
 </resources>

--- a/app/src/psi/res/values-zh-rCN/strings.xml
+++ b/app/src/psi/res/values-zh-rCN/strings.xml
@@ -13,4 +13,5 @@
     <string name="feedback_tab_hnqis_all">"所有"</string>
     <string name="feedback_tab_hnqis_critical">"危急"</string>
     <string name="feedback_tab_hnqis_non_critical">"不重要"</string>
+    <string name="feedback_malformed_error">"**錯誤**：數據元素的反饋格式錯誤 %s"</string>
 </resources>

--- a/app/src/psi/res/values/strings.xml
+++ b/app/src/psi/res/values/strings.xml
@@ -8,4 +8,10 @@
     <string name="unexpected_error_message">An unexpected error has occurred. Review your configuration or contact with your administrator</string>
     <string name="feedback_show_only_failed">Show only failed</string>
     <string name="feedback_url">"See full feedback at:"</string>
+    <string name="feedback_tab_rdqa_by_indicator">"By indicator"</string>
+    <string name="feedback_tab_rdqa_by_technical_area">"By technical area"</string>
+    <string name="feedback_tab_hnqis_all">"All"</string>
+    <string name="feedback_tab_hnqis_critical">"Critical"</string>
+    <string name="feedback_tab_hnqis_non_critical">"Non Critical"</string>
+
 </resources>

--- a/app/src/psi/res/values/strings.xml
+++ b/app/src/psi/res/values/strings.xml
@@ -13,5 +13,5 @@
     <string name="feedback_tab_hnqis_all">"All"</string>
     <string name="feedback_tab_hnqis_critical">"Critical"</string>
     <string name="feedback_tab_hnqis_non_critical">"Non Critical"</string>
-
+    <string name="feedback_malformed_error">"**Error** : Malformed feedback json for Data Element %s"</string>
 </resources>

--- a/app/src/testPsi/java/org/dhis2/utils/JsonCheckerTest.kt
+++ b/app/src/testPsi/java/org/dhis2/utils/JsonCheckerTest.kt
@@ -1,0 +1,34 @@
+package org.dhis2.utils
+
+import org.junit.Assert
+import org.junit.Test
+
+class JsonCheckerTest {
+
+    @Test
+    fun `should return text for simple text`() {
+        val checker = JsonChecker()
+
+        val result = checker.check("simple text")
+
+        Assert.assertTrue(result is JsonCheckResult.Text)
+    }
+
+    @Test
+    fun `should return json for valid json text`() {
+        val checker = JsonChecker()
+
+        val result = checker.check("[{\"prop\":\"value\" }]")
+
+        Assert.assertTrue(result is JsonCheckResult.Json)
+    }
+
+    @Test
+    fun `should return malformed json for malformed json text`() {
+        val checker = JsonChecker()
+
+        val result = checker.check("[{\"prop\":\"value\"")
+
+        Assert.assertTrue(result is JsonCheckResult.MalformedJson)
+    }
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close https://app.clickup.com/t/cn27kd
* **Related pull-requests:

###   :gear: branches 
**app**: 
       Origin: feature/feedback_multilingual_support Target: develop-psi
**dhis2-android-SDK**: 
       Origin: feature/bring_last_changes_in_1_3_1
**dhis2-rule-engine**: 
       Origin: f8a22e9e20c048e0e6f667f4817f420b7eb01731
### :tophat: What is the goal?

Add multilingual support to feedback nodes in the feedback tree.

### :memo: How is it being implemented?

- [x] Translate feedback tabs
- [x] Create JsonChecker
- [x] Create MultilingualFeedback entity
- [x] Create json malformed error strings
- [x] Implement parse feedback json

### :boom: How can it be tested?

Modify feedback attributes in the current data elements with the next cases:
* Valid json for several languages
* Invalid json 
* feedback text directly

**Use case 1:** -  open feedback and feedback nodes with a valid json configuration should show the text in the current language
**Use case 2:** -  open feedback and feedback nodes with a valid json configuration should show the first translated text if feedback does not support the current language
**Use case 3:** -  open feedback and feedback nodes with an invalid valid json configuration should show an error text showing the data element uid
**Use case 4:** -  open feedback and feedback nodes with a text configuration (not json) should show the text directly

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

