### PR TITLE
Feature/share feedback changes

### DIFF
--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2021-03-17 12:14","gitSha":"5f9e2bd5f"}
+{"buildTime":"2021-03-17 12:39","gitSha":"30874c330"}

--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2021-02-15 11:25","gitSha":"ea5d23526"}
+{"buildTime":"2021-03-17 12:14","gitSha":"5f9e2bd5f"}

--- a/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/enrollment/EnrollmentInfo.kt
+++ b/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/enrollment/EnrollmentInfo.kt
@@ -1,0 +1,10 @@
+package org.dhis2.usescases.teiDashboard.dashboardsfragments.enrollment
+
+import java.util.Date
+
+data class EnrollmentInfo(
+    val enrollmentUid: String,
+    val programUid: String,
+    val enrollmentDate: Date,
+    val programName: String
+)

--- a/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/enrollment/EnrollmentInfoD2Repository.kt
+++ b/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/enrollment/EnrollmentInfoD2Repository.kt
@@ -1,0 +1,21 @@
+package org.dhis2.usescases.teiDashboard.dashboardsfragments.enrollment
+
+import org.hisp.dhis.android.core.D2
+
+class EnrollmentInfoD2Repository(private val d2: D2) : EnrollmentInfoRepository {
+    override fun get(enrollmentUid: String): EnrollmentInfo {
+
+        val enrollment =
+            d2.enrollmentModule().enrollments().byUid().eq(enrollmentUid).one().blockingGet()
+
+        val program =
+            d2.programModule().programs().byUid().eq(enrollment.program()).one().blockingGet()
+
+        return EnrollmentInfo(
+            enrollment.uid()!!,
+            enrollment.program()!!,
+            enrollment.enrollmentDate()!!,
+            program.displayName()!!
+        )
+    }
+}

--- a/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/enrollment/GetEnrollmentInfo.kt
+++ b/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/enrollment/GetEnrollmentInfo.kt
@@ -1,0 +1,12 @@
+package org.dhis2.usescases.teiDashboard.dashboardsfragments.enrollment
+
+interface EnrollmentInfoRepository {
+    fun get(enrollmentUid: String): EnrollmentInfo
+}
+
+class GetEnrollmentInfo(private val enrollmentInfoRepository: EnrollmentInfoRepository) {
+    operator fun invoke(enrollmentUid: String): EnrollmentInfo {
+        return enrollmentInfoRepository.get(enrollmentUid)
+    }
+}
+

--- a/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/FeedbackContentFragment.kt
+++ b/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/FeedbackContentFragment.kt
@@ -20,8 +20,12 @@ import org.dhis2.core.ui.tree.TreeAdapter
 import org.dhis2.databinding.FragmentFeedbackContentBinding
 import org.dhis2.usescases.general.FragmentGlobalAbstract
 import org.dhis2.usescases.teiDashboard.TeiDashboardMobileActivity
+import org.dhis2.usescases.teiDashboard.dashboardsfragments.enrollment.EnrollmentInfo
 import org.dhis2.utils.customviews.TextInputAutoCompleteTextView
 import java.net.URL
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import javax.inject.Inject
 
 class FeedbackContentFragment : FragmentGlobalAbstract(),
@@ -103,30 +107,42 @@ class FeedbackContentFragment : FragmentGlobalAbstract(),
     override fun render(state: FeedbackContentState) {
         return when (state) {
             is FeedbackContentState.Loading -> renderLoading()
-            is FeedbackContentState.Loaded -> renderLoaded(state.feedback, state.position, state.validations)
+            is FeedbackContentState.Loaded -> renderLoaded(
+                state.feedback,
+                state.position,
+                state.validations
+            )
             is FeedbackContentState.ValidationsWithError -> {
                 renderError(getString(R.string.unexpected_error_message))
                 showValidations(state.validations)
             }
             is FeedbackContentState.SharingFeedback -> shareFeedback(
-                state.feedbackText,
-                state.serverUrl,
-                state.enrollmentUID
+                state.enrollmentInfo,
+                state.serverUrl
             )
             is FeedbackContentState.NotFound -> renderError(getString(R.string.empty_tei_no_add))
             is FeedbackContentState.UnexpectedError -> renderError(getString(R.string.unexpected_error_message))
         }
     }
 
-    private fun shareFeedback(feedbackText: String, serverUrl: String, enrollmentUID: String) {
+    private fun shareFeedback(
+        enrollmentInfo: EnrollmentInfo,
+        serverUrl: String
+    ) {
         val sendIntent: Intent = Intent().apply {
             action = Intent.ACTION_SEND
 
             val url = URL(serverUrl)
+            val feedbackUrl =
+                URL("https://feedback.psi-mis.org/${url.host}/${enrollmentInfo.enrollmentUid}")
+            val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
 
-            val feedbackUrl = URL("https://feedback.psi-mis.org/${url.host}/$enrollmentUID")
+            val assessmentDateText =
+                "Assessment conducted on: ${dateFormat.format(enrollmentInfo.enrollmentDate)}"
+            val assessmentTypeText = "Assessment type: ${enrollmentInfo.programName}"
+            val urlText = "${getString(R.string.feedback_url)} \n $feedbackUrl"
 
-            val finalText = "$feedbackText \n  ${getString(R.string.feedback_url)} \n $feedbackUrl"
+            val finalText = "$assessmentDateText\n$assessmentTypeText\n\n$urlText"
 
             putExtra(Intent.EXTRA_TEXT, finalText)
 

--- a/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/FeedbackContentFragment.kt
+++ b/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/FeedbackContentFragment.kt
@@ -138,8 +138,9 @@ class FeedbackContentFragment : FragmentGlobalAbstract(),
             val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
 
             val assessmentDateText =
-                "Assessment conducted on: ${dateFormat.format(enrollmentInfo.enrollmentDate)}"
-            val assessmentTypeText = "Assessment type: ${enrollmentInfo.programName}"
+                "${getString(R.string.feedback_share_conducted)}: ${dateFormat.format(enrollmentInfo.enrollmentDate)}"
+            val assessmentTypeText =
+                "${getString(R.string.feedback_share_assessment_type)}: ${enrollmentInfo.programName}"
             val urlText = "${getString(R.string.feedback_url)} \n $feedbackUrl"
 
             val finalText = "$assessmentDateText\n$assessmentTypeText\n\n$urlText"

--- a/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/FeedbackModule.kt
+++ b/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/FeedbackModule.kt
@@ -7,6 +7,9 @@ import org.dhis2.data.dagger.PerFragment
 import org.dhis2.data.dhislogic.DhisEventUtils
 import org.dhis2.usescases.teiDashboard.dashboardfragments.teidata.TeiDataRepository
 import org.dhis2.usescases.teiDashboard.dashboardfragments.teidata.TeiDataRepositoryImpl
+import org.dhis2.usescases.teiDashboard.dashboardsfragments.enrollment.EnrollmentInfoD2Repository
+import org.dhis2.usescases.teiDashboard.dashboardsfragments.enrollment.EnrollmentInfoRepository
+import org.dhis2.usescases.teiDashboard.dashboardsfragments.enrollment.GetEnrollmentInfo
 import org.dhis2.usescases.teiDashboard.dashboardsfragments.systemInfo.GetSystemInfo
 import org.dhis2.usescases.teiDashboard.dashboardsfragments.systemInfo.SystemInfoD2Repository
 import org.dhis2.usescases.teiDashboard.dashboardsfragments.systemInfo.SystemInfoRepository
@@ -32,9 +35,10 @@ class FeedbackModule(
     @PerFragment
     fun provideFeedbackContentPresenter(
         getFeedback: GetFeedback,
-        getSystemInfo: GetSystemInfo
+        getSystemInfo: GetSystemInfo,
+        getEnrollmentInfo: GetEnrollmentInfo
     ): FeedbackContentPresenter {
-        return FeedbackContentPresenter(getFeedback, getSystemInfo)
+        return FeedbackContentPresenter(getFeedback, getSystemInfo, getEnrollmentInfo)
     }
 
     @Provides
@@ -51,6 +55,12 @@ class FeedbackModule(
     @PerFragment
     fun provideGetSystemInfo(systemInfoRepository: SystemInfoRepository): GetSystemInfo {
         return GetSystemInfo(systemInfoRepository)
+    }
+
+    @Provides
+    @PerFragment
+    fun provideGetEnrollmentInfo(enrollmentInfoRepository: EnrollmentInfoRepository): GetEnrollmentInfo {
+        return GetEnrollmentInfo(enrollmentInfoRepository)
     }
 
     @Provides
@@ -81,5 +91,11 @@ class FeedbackModule(
     @PerFragment
     fun provideSystemInfoRepository(d2: D2): SystemInfoRepository {
         return SystemInfoD2Repository(d2)
+    }
+
+    @Provides
+    @PerFragment
+    fun provideEnrollmentInfoRepository(d2: D2): EnrollmentInfoRepository {
+        return EnrollmentInfoD2Repository(d2)
     }
 }

--- a/app/src/psi/res/values-ar/strings.xml
+++ b/app/src/psi/res/values-ar/strings.xml
@@ -20,4 +20,6 @@
     <string name="feedback_order_invalid">"ترتيب ردود الفعل غير صالحة في العنصر البيانات %s"</string>
     <string name="feedback_order_duplicate">"مكررة ردود الفعل النظام في عناصر البيانات %s"</string>
     <string name="feedback_order_gap">"برنامج مرحلةS% يحتوي ثغرات أجل ردود الفعل"</string>
+    <string name="feedback_share_conducted">"تم إجراء التقييم على"</string>
+    <string name="feedback_share_assessment_type">"نوع التقييم"</string>
 </resources>

--- a/app/src/psi/res/values-cs/strings.xml
+++ b/app/src/psi/res/values-cs/strings.xml
@@ -20,4 +20,6 @@
     <string name="feedback_order_invalid">"Neplatný objednat zpětná vazba v datovém prvku %s"</string>
     <string name="feedback_order_duplicate">"Zpětná vazba pořadí duplicitní v datových prvcích %s"</string>
     <string name="feedback_order_gap">"fáze programu %s obsahuje mezery zpětná vazba pořadí"</string>
+    <string name="feedback_share_conducted">"Hodnocení provedeno dne"</string>
+    <string name="feedback_share_assessment_type">"Typ posouzení"</string>
 </resources>

--- a/app/src/psi/res/values-es/strings.xml
+++ b/app/src/psi/res/values-es/strings.xml
@@ -20,4 +20,6 @@
     <string name="feedback_order_invalid">"Orden de retroalimentación inválido en el elemento de datos %s"</string>
     <string name="feedback_order_duplicate">"Duplicado en el orden de retroalimentación en los elementos de datos %s"</string>
     <string name="feedback_order_gap">"Etapa de programa %s contiene lagunas en su orden de realimentación"</string>
+    <string name="feedback_share_conducted">"Evaluación realizada el"</string>
+    <string name="feedback_share_assessment_type">"Tipo de evaluación"</string>
 </resources>

--- a/app/src/psi/res/values-fr/strings.xml
+++ b/app/src/psi/res/values-fr/strings.xml
@@ -20,4 +20,6 @@
     <string name="feedback_order_invalid">"Ordre du retour d'information non valide dans l'élément de données %s"</string>
     <string name="feedback_order_duplicate">"Doublon dans l'ordre du retour d'information pour les éléments de données %s"</string>
     <string name="feedback_order_gap">"Étape du programme %s contient des trous dans l'ordre du retour d'information"</string>
+    <string name="feedback_share_conducted">"Évaluation effectuée le"</string>
+    <string name="feedback_share_assessment_type">"Type d'évaluation"</string>
 </resources>

--- a/app/src/psi/res/values-id/strings.xml
+++ b/app/src/psi/res/values-id/strings.xml
@@ -20,4 +20,6 @@
     <string name="feedback_order_invalid">"Agar umpan balik tidak valid di elemen data %s"</string>
     <string name="feedback_order_duplicate">"Umpan balik urutan duplikat di elemen data %s"</string>
     <string name="feedback_order_gap">"Program tahap %s berisi agar umpan balik celah"</string>
+    <string name="feedback_share_conducted">"Penilaian dilakukan pada""</string>
+    <string name="feedback_share_assessment_type">"Jenis penilaian"</string>
 </resources>

--- a/app/src/psi/res/values-km/strings.xml
+++ b/app/src/psi/res/values-km/strings.xml
@@ -20,4 +20,6 @@
     <string name="feedback_order_invalid">"គោលបំណងមតិអ្នកប្រើមិនត្រឹមត្រូវនៅក្នុងធាតុទិន្នន័យ %s"</string>
     <string name="feedback_order_duplicate">"មតិជាលំដាប់នៅក្នុងស្ទួនធាតុទិន្នន័យ %s"</string>
     <string name="feedback_order_gap">"កម្មវិធីដំណាក់កាល %s បានមានចន្លោះគោលបំណងមតិអ្នកប្រើ"</string>
+    <string name="feedback_share_conducted">"ការវាយតំលៃធ្វើឡើងលើ"</string>
+    <string name="feedback_share_assessment_type">"ប្រភេទវាយតម្លៃ"</string>
 </resources>

--- a/app/src/psi/res/values-lo/strings.xml
+++ b/app/src/psi/res/values-lo/strings.xml
@@ -20,4 +20,6 @@
     <string name="feedback_order_invalid">"ຄໍາສັ່ງຕໍານິຕິຊົມບໍ່ຖືກຕ້ອງໃນອົງປະກອບຂໍ້ມູນ %s"</string>
     <string name="feedback_order_duplicate">"ຊ້ໍາກັນຕໍານິຕິຊົມສັ່ງຊື້ອົງປະກອບຂໍ້ມູນ %s"</string>
     <string name="feedback_order_gap">"ໂຄງການຂັ້ນຕອນຂອງການ %s ມີຊ່ອງຫວ່າງເພື່ອຕໍານິຕິຊົມ"</string>
+    <string name="feedback_share_conducted">"ການປະເມີນຜົນປະຕິບັດ"</string>
+    <string name="feedback_share_assessment_type">"ປະເພດການປະເມີນຜົນ"</string>
 </resources>

--- a/app/src/psi/res/values-nb/strings.xml
+++ b/app/src/psi/res/values-nb/strings.xml
@@ -20,4 +20,6 @@
     <string name="feedback_order_invalid">"Ugyldig tilbakemelding rekkefølge i dataelement %s"</string>
     <string name="feedback_order_duplicate">"Tilbakemelding orden duplikat i dataelementene %s"</string>
     <string name="feedback_order_gap">"program scenen %s inneholder tilbakemeldinger ordre hull"</string>
+    <string name="feedback_share_conducted">"Vurdering utført på"</string>
+    <string name="feedback_share_assessment_type">"Vurderingstype"</string>
 </resources>

--- a/app/src/psi/res/values-pt/strings.xml
+++ b/app/src/psi/res/values-pt/strings.xml
@@ -20,4 +20,6 @@
     <string name="feedback_order_invalid">"fim de feedback inválida no elemento de dados %s"</string>
     <string name="feedback_order_duplicate">"duplicado ordem realimentação nos elementos de dados %s"</string>
     <string name="feedback_order_gap">"fase programa %s contém lacunas ordem realimentação"</string>
+    <string name="feedback_share_conducted">"Avaliação realizada em"</string>
+    <string name="feedback_share_assessment_type">"Tipo de avaliação"</string>
 </resources>

--- a/app/src/psi/res/values-ru/strings.xml
+++ b/app/src/psi/res/values-ru/strings.xml
@@ -20,4 +20,6 @@
     <string name="feedback_order_invalid">"Недопустимый порядок обратной связи в элементе данных %s"</string>
     <string name="feedback_order_duplicate">"Обратная связь порядок дубликат в элементах данных %s"</string>
     <string name="feedback_order_gap">"Программа этапа %s содержит пробелы порядка обратной связи"</string>
+    <string name="feedback_share_conducted">"Оценка проводится"</string>
+    <string name="feedback_share_assessment_type">"Тип оценки"</string>
 </resources>

--- a/app/src/psi/res/values-sv/strings.xml
+++ b/app/src/psi/res/values-sv/strings.xml
@@ -20,4 +20,6 @@
     <string name="feedback_order_invalid">"Ogiltigt återkopplings ordning i dataelementet %s"</string>
     <string name="feedback_order_duplicate">"Återkopplings ordning två exemplar på dataelementen %s"</string>
     <string name="feedback_order_gap">"Programsteget %s innehåller återkopplingsorder luckor"</string>
+    <string name="feedback_share_conducted">"Bedömning utförd på"</string>
+    <string name="feedback_share_assessment_type">"Bedömningstyp"</string>
 </resources>

--- a/app/src/psi/res/values-vi/strings.xml
+++ b/app/src/psi/res/values-vi/strings.xml
@@ -20,4 +20,6 @@
     <string name="feedback_order_invalid">"Để phản hồi không hợp lệ trong phần tử dữ liệu %s"</string>
     <string name="feedback_order_duplicate">"Để phản hồi trùng lặp trong các yếu tố dữ liệu %s"</string>
     <string name="feedback_order_gap">"Chương trình sân khấu %s chứa khoảng trống để phản hồi"</string>
+    <string name="feedback_share_conducted">"Đánh giá được thực hiện vào"</string>
+    <string name="feedback_share_assessment_type">"Loại đánh giá"</string>
 </resources>

--- a/app/src/psi/res/values-zh-rCN/strings.xml
+++ b/app/src/psi/res/values-zh-rCN/strings.xml
@@ -20,4 +20,6 @@
     <string name="feedback_order_invalid">"在数据元素无效反馈顺序 %s"</string>
     <string name="feedback_order_duplicate">"在数据部分的反馈顺序重复 %s"</string>
     <string name="feedback_order_gap">"计划阶段％s包含反馈顺序差距"</string>
+    <string name="feedback_share_conducted">"進行評估"</string>
+    <string name="feedback_share_assessment_type">"評估類型"</string>
 </resources>

--- a/app/src/psi/res/values/strings.xml
+++ b/app/src/psi/res/values/strings.xml
@@ -20,4 +20,6 @@
     <string name="feedback_order_invalid">"Invalid feedback order in data element %s"</string>
     <string name="feedback_order_duplicate">"Feedback order duplicate in the data elements %s"</string>
     <string name="feedback_order_gap">"Program stage %s contains feedback order gaps"</string>
+    <string name="feedback_share_conducted">"Assessment conducted on"</string>
+    <string name="feedback_share_assessment_type">"Assessment type"</string>
 </resources>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/fn3f92
* **Related pull-requests:

###   :gear: branches 
**app**: 
       Origin: feature/share_feedback_changes Target: develop-psi
**dhis2-android-SDK**: 
       Origin: develop-eyeseetea
**dhis2-rule-engine**: 
       Origin: 7450edfa3ce658690c2ec35b1d085d3d11731ba8
### :tophat: What is the goal?

Share feedback changes according to https://github.com/EyeSeeTea/dhis2-android-capture-app-psi-fork/issues/10

### :memo: How is it being implemented?

- change the share feedback text retrieving necessary data from the DB

### :boom: How can it be tested?

**Use case 1:** - open feedback and click on share fab to share the content

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

