### PR TITLE
Refactor the treeview refresh after expand/collapse

### DIFF
--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2021-02-15 11:25","gitSha":"ea5d23526"}
+{"buildTime":"2021-03-22 09:45","gitSha":"5f9e2bd5f"}

--- a/app/src/psi/java/org/dhis2/core/ui/tree/TreeAdapter.kt
+++ b/app/src/psi/java/org/dhis2/core/ui/tree/TreeAdapter.kt
@@ -6,9 +6,8 @@ import androidx.recyclerview.widget.RecyclerView
 import org.dhis2.core.types.Tree
 
 class TreeAdapter(
-    root: Tree.Root<*>,
     private val binders: List<TreeAdapterBinder>,
-    private val onTreeClickListener: (node: Tree<*>, position: Int) -> Unit,
+    private val onTreeClickListener: (node: Tree<*>) -> Unit,
     private val displayRoot: Boolean = false
 ) :
     RecyclerView.Adapter<RecyclerView.ViewHolder?>() {
@@ -16,8 +15,11 @@ class TreeAdapter(
     private var displayNodes: MutableList<Tree<*>> = mutableListOf()
     private var levelByNodes = HashMap<Tree<*>, Int>()
 
-    init {
+    fun refresh(root: Tree.Root<*>) {
+        displayNodes.clear()
+        levelByNodes.clear()
         findDisplayNodes(root)
+        notifyDataSetChanged()
     }
 
     private fun findDisplayNodes(root: Tree.Root<*>) {
@@ -66,7 +68,7 @@ class TreeAdapter(
             val node = displayNodes[viewHolder.adapterPosition]
 
             if (node is Tree.Node) {
-                onTreeClickListener(node, viewHolder.adapterPosition)
+                onTreeClickListener(node)
             }
         }
 

--- a/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/FeedbackContentFragment.kt
+++ b/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/FeedbackContentFragment.kt
@@ -76,6 +76,13 @@ class FeedbackContentFragment : FragmentGlobalAbstract(),
             presenter.shareFeedback(binding.failedCheckBox.isChecked)
         }
 
+        adapter = TreeAdapter(listOf(FeedbackItemBinder(), FeedbackHelpItemBinder()),
+            { node: Tree<*> ->
+                presenter.expand(node )
+            })
+
+        binding.feedbackRecyclerView.adapter = adapter
+
         return binding.root
     }
 
@@ -103,7 +110,10 @@ class FeedbackContentFragment : FragmentGlobalAbstract(),
     override fun render(state: FeedbackContentState) {
         return when (state) {
             is FeedbackContentState.Loading -> renderLoading()
-            is FeedbackContentState.Loaded -> renderLoaded(state.feedback, state.position, state.validations)
+            is FeedbackContentState.Loaded -> renderLoaded(
+                state.feedback,
+                state.validations
+            )
             is FeedbackContentState.ValidationsWithError -> {
                 renderError(getString(R.string.unexpected_error_message))
                 showValidations(state.validations)
@@ -174,12 +184,12 @@ class FeedbackContentFragment : FragmentGlobalAbstract(),
         binding.failedCheckBox.isEnabled = false
     }
 
-    private fun renderLoaded(feedback: Tree.Root<*>, position: Int, validations: List<Validation>) {
+    private fun renderLoaded(feedback: Tree.Root<*>, validations: List<Validation>) {
         binding.msgFeedback.visibility = View.GONE
         binding.spinner.visibility = View.GONE
         binding.failedCheckBox.isEnabled = true
 
-        setFeedbackAdapter(feedback, position)
+        setFeedbackAdapter(feedback)
 
         showValidations(validations)
     }
@@ -246,14 +256,10 @@ class FeedbackContentFragment : FragmentGlobalAbstract(),
         }
     }
 
-    private fun setFeedbackAdapter(feedback: Tree.Root<*>, scrollTo: Int) {
-        val adapter = TreeAdapter(feedback, listOf(FeedbackItemBinder(), FeedbackHelpItemBinder()),
-            { node: Tree<*>, position: Int ->
-                presenter.expand(node, position)
-            })
+    private lateinit var adapter: TreeAdapter
 
-        binding.feedbackRecyclerView.adapter = adapter
-        binding.feedbackRecyclerView.smoothScrollToPosition(scrollTo)
+    private fun setFeedbackAdapter(feedback: Tree.Root<*>) {
+        adapter.refresh(feedback)
     }
 
     companion object {

--- a/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/FeedbackContentPresenter.kt
+++ b/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/FeedbackContentPresenter.kt
@@ -16,7 +16,6 @@ sealed class FeedbackContentState {
     data class Loaded(
         val feedback: Tree.Root<*>,
         val onlyFailedFilter: Boolean,
-        val position: Int,
         val validations: List<Validation>
     ) :
         FeedbackContentState()
@@ -84,13 +83,10 @@ class FeedbackContentPresenter(
                 })
     }
 
-    fun expand(node: Tree<*>, position: Int) {
+    fun expand(node: Tree<*>) {
         if (lastLoaded != null && node is Tree.Node) {
             lastLoaded =
-                lastLoaded!!.copy(
-                    feedback = lastLoaded!!.feedback.expand(node),
-                    position = position
-                )
+                lastLoaded!!.copy(feedback = lastLoaded!!.feedback.expand(node))
             render(lastLoaded!!)
         }
     }
@@ -112,7 +108,6 @@ class FeedbackContentPresenter(
                 lastLoaded = FeedbackContentState.Loaded(
                     finalFeedback,
                     onlyFailedFilter,
-                    0,
                     feedbackResponse.validations
                 )
                 render(lastLoaded!!)


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/fn3fcd
* **Related pull-requests**: 

###   :gear: branches 
**app**: 
       Origin: fix/bug_with_scroll_to_expand_collapse_feedback_items Target: develop-psi
**dhis2-android-SDK**: 
       Origin: feature/develop_eyeseetea
**dhis2-rule-engine**: 
       Origin: 7450edfa3ce658690c2ec35b1d085d3d11731ba8
### :tophat: What is the goal?

Fix scroll issue after expand/collapse feedback items

### :memo: How is it being implemented?

I have refactored the refreshing approach using notifyDataSetChanged in the recycler view adapter. Now the restore scroll position is realized by the adapter.

### :boom: How can it be tested?

**Use case 1:** - From the feedback and to expand and collapse items

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

