### PR TITLE
PSI - Remove custom program stage name in event list

### DIFF
--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2021-04-07 12:15","gitSha":"4ec688e48"}
+{"buildTime":"2021-06-11 06:54","gitSha":"44626bb3d"}

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataPresenterImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataPresenterImpl.java
@@ -167,7 +167,8 @@ public class TEIDataPresenterImpl implements TEIDataContracts.Presenter {
                                                     filterManager.getAssignedFilter(),
                                                     filterManager.getEventStatusFilters(),
                                                     filterManager.getCatOptComboFilters(),
-                                                    filterManager.getSortingItem()
+                                                    filterManager.getSortingItem(),
+                                                    false
                                             ).toFlowable(),
                                             ruleEngineRepository.updateRuleEngine()
                                                     .flatMap(ruleEngine -> ruleEngineRepository.reCalculate()),

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TeiDataRepository.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TeiDataRepository.kt
@@ -22,7 +22,8 @@ interface TeiDataRepository {
         assignedToMe: Boolean,
         eventStatusFilters: MutableList<EventStatus>,
         catOptComboFilters: MutableList<CategoryOptionCombo>,
-        sortingItem: SortingItem?
+        sortingItem: SortingItem?,
+        replaceProgramStageName: Boolean = false
     ): Single<List<EventViewModel>>
 
     fun getEnrollment(): Single<Enrollment>

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TeiDataRepositoryImpl.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TeiDataRepositoryImpl.kt
@@ -41,7 +41,8 @@ class TeiDataRepositoryImpl(
         assignedToMe: Boolean,
         eventStatusFilters: MutableList<EventStatus>,
         catOptComboFilters: MutableList<CategoryOptionCombo>,
-        sortingItem: SortingItem?
+        sortingItem: SortingItem?,
+        replaceProgramStageName: Boolean
     ): Single<List<EventViewModel>> {
         var eventRepo = d2.eventModule().events().byEnrollmentUid().eq(enrollmentUid)
 
@@ -59,9 +60,9 @@ class TeiDataRepositoryImpl(
         )
 
         return if (groupedByStage) {
-            getGroupedEvents(eventRepo, selectedStage, sortingItem)
+            getGroupedEvents(eventRepo, selectedStage, sortingItem, replaceProgramStageName)
         } else {
-            getTimelineEvents(eventRepo, sortingItem)
+            getTimelineEvents(eventRepo, sortingItem,replaceProgramStageName)
         }
     }
 
@@ -93,7 +94,8 @@ class TeiDataRepositoryImpl(
     private fun getGroupedEvents(
         eventRepository: EventCollectionRepository,
         selectedStage: String?,
-        sortingItem: SortingItem?
+        sortingItem: SortingItem?,
+        replaceProgramStageName: Boolean = false
     ): Single<List<EventViewModel>> {
         val eventViewModels = mutableListOf<EventViewModel>()
         var eventRepo: EventCollectionRepository
@@ -136,13 +138,14 @@ class TeiDataRepositoryImpl(
                             val showTopShadow = index == 0
                             val showBottomShadow = index == eventList.size - 1
 
-                            val programStageDisplayName = getProgramStageName(d2, event.uid())
-                            val editedProgramStage = programStage.toBuilder().displayName(programStageDisplayName).build();
+                            val finalProgramStage = if (replaceProgramStageName == true)
+                                programStage.toBuilder().displayName(getProgramStageName(d2, event.uid())).build()
+                            else programStage
 
                             eventViewModels.add(
                                 EventViewModel(
                                     EventViewModelType.EVENT,
-                                    editedProgramStage,
+                                    finalProgramStage,
                                     event,
                                     0,
                                     null,
@@ -170,7 +173,8 @@ class TeiDataRepositoryImpl(
 
     private fun getTimelineEvents(
         eventRepository: EventCollectionRepository,
-        sortingItem: SortingItem?
+        sortingItem: SortingItem?,
+        replaceProgramStageName: Boolean = false
     ): Single<List<EventViewModel>> {
         val eventViewModels = mutableListOf<EventViewModel>()
         var eventRepo = eventRepository
@@ -186,15 +190,16 @@ class TeiDataRepositoryImpl(
                         .uid(event.programStage())
                         .blockingGet()
 
-                    val programStageDisplayName = getProgramStageName(d2, event.uid())
-                    val editedProgramStage = programStage.toBuilder().displayName(programStageDisplayName).build();
+                    val finalProgramStage = if (replaceProgramStageName == true)
+                        programStage.toBuilder().displayName(getProgramStageName(d2, event.uid())).build()
+                    else programStage
 
                     val showTopShadow = index == 0
                     val showBottomShadow = index == eventList.size - 1
                     eventViewModels.add(
                         EventViewModel(
                             EventViewModelType.EVENT,
-                            editedProgramStage,
+                            finalProgramStage,
                             event,
                             0,
                             null,
@@ -204,7 +209,7 @@ class TeiDataRepositoryImpl(
                                 .uid(event.organisationUnit()).blockingGet().displayName()
                                 ?: "",
                             catComboName = getCatComboName(event.attributeOptionCombo()),
-                            dataElementValues = getEventValues(event.uid(), editedProgramStage.uid()),
+                            dataElementValues = getEventValues(event.uid(), finalProgramStage.uid()),
                             groupedByStage = false
                         )
                     )

--- a/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/GetFeedback.kt
+++ b/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/GetFeedback.kt
@@ -330,7 +330,8 @@ class GetFeedback(
             false,
             mutableListOf(),
             mutableListOf(),
-            null
+            null,
+            true
         ).blockingGet()
     }
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/m3ba8j

###   :gear: branches 
**app**: 
       Origin: feature/remove_title_pattern_in_event_list Target: develop-psi
**dhis2-android-SDK**: 
       Origin: develop_eyeseetea
**dhis2-rule-engine**: 
       Origin: 7450edfa3ce658690c2ec35b1d085d3d11731ba8
### :tophat: What is the goal?

Remove custom program stage name in event list

### :memo: How is it being implemented?

- [x] Remove custom program stage from event list according to title pattern attribute 

First I attempt to remove the customization from TeiDataRepositoryImp , but removing it from here also remove from feedback tab. I try to create a custom repository for feedback data to avoid add more changes to TeiDataRepositoryImp and avoid conflicts in the future when we bring last changes in the official app but I was duplicating a lot of code. Finally, I have reverted these changes and I have modified TeiDataRepositoryImp adding a new parameter to set if the default program stage must to be replaced, This parameter is set to false from the event list and to true from the feedback tab


### :boom: How can it be tested?

**use case 1**:  event list should show the default program stage name
**use case 2**: feedback tab should show custom program stage according to title pattern attribute

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-