### PR TITLE
Search by biometrics using all returned guids

### DIFF
--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2021-08-26 12:53","gitSha":"f9dc74578"}
+{"buildTime":"2021-08-31 11:25","gitSha":"86fe8eb97"}

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
@@ -255,13 +255,19 @@ public class SearchRepositoryImpl implements SearchRepository {
             String dataValue = searchParametersModel.getQueryData().get(dataId);
             boolean isUnique = d2.trackedEntityModule().trackedEntityAttributes().uid(dataId).blockingGet().unique();
             if (isUnique) {
-                trackedEntityInstanceQuery = trackedEntityInstanceQuery.byAttribute(dataId).eq(dataValue);
+                if (dataValue.contains(";")) {
+                    trackedEntityInstanceQuery = trackedEntityInstanceQuery.byAttribute(dataId).in(dataValue);
+                }else {
+                    trackedEntityInstanceQuery = trackedEntityInstanceQuery.byAttribute(dataId).eq(dataValue);
+                }
             } else if (dataValue.contains("_os_")) {
                 dataValue = dataValue.split("_os_")[1];
                 trackedEntityInstanceQuery = trackedEntityInstanceQuery.byAttribute(dataId).eq(dataValue);
             } else if (dataValue.contains("_ou_")) {
                 dataValue = dataValue.split("_ou_")[0];
                 trackedEntityInstanceQuery = trackedEntityInstanceQuery.byAttribute(dataId).eq(dataValue);
+            } else if (dataValue.contains(";")) {
+                trackedEntityInstanceQuery = trackedEntityInstanceQuery.byAttribute(dataId).in(dataValue);
             } else
                 trackedEntityInstanceQuery = trackedEntityInstanceQuery.byAttribute(dataId).like(dataValue);
         }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** ORM multiple answers mq82na
* **Related Pull request:**  https://github.com/EyeSeeTea/dhis2-android-sdk/pull/428

###   :gear: branches 
**app**: 
       Origin:feature/simprints_orm_multiple_answers_mq82na Target: develop-simprints
**dhis2-android-SDK**: 
       Origin: feature/enable_in_operator_in_att_for_TEI_queries
**dhis2-rule-engine**: 
       Origin: ec2b39f051acd5f1a28b2cf940e83176857f4d76
### :tophat: What is the goal?

Search all Guids returned by Simprints in a TEI search

### :memo: How is it being implemented?

- [x] Search by biometrics using all returned Guids

### :boom: How can it be tested?

**use case 1**:  Create n TEIs using the same image, the search using the image should return n TEIs

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-