### PR TITLE
Simprints - Verify in event if biometrics DE exists

### DIFF
--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2021-08-26 18:17","gitSha":"c07be6cf1"}
+{"buildTime":"2021-09-02 14:39","gitSha":"41db67fe0"}

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureActivity.java
@@ -84,6 +84,19 @@ public class EventCaptureActivity extends ActivityGlobalAbstract implements Even
         return bundle;
     }
 
+    public static Bundle getActivityBundleWithBiometrics(@NonNull String eventUid,
+            @NonNull String programUid,
+            @NonNull EventMode eventMode,
+            @NonNull String guid,
+            @NonNull int status,
+            @NonNull String orgUnitUid) {
+        Bundle bundle = getActivityBundle(eventUid, programUid,eventMode);
+        bundle.putString(BIOMETRICS_GUID, guid);
+        bundle.putInt(BIOMETRICS_VERIFICATION_STATUS, status);
+        bundle.putString(BIOMETRICS_TEI_ORGANISATION_UNIT, orgUnitUid);
+        return bundle;
+    }
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         eventCaptureComponent = (ExtensionsKt.app(this)).userComponent().plus(

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialActivity.java
@@ -94,6 +94,10 @@ import kotlin.Unit;
 import timber.log.Timber;
 
 import static android.text.TextUtils.isEmpty;
+
+import static org.dhis2.usescases.biometrics.BiometricConstantsKt.BIOMETRICS_GUID;
+import static org.dhis2.usescases.biometrics.BiometricConstantsKt.BIOMETRICS_TEI_ORGANISATION_UNIT;
+import static org.dhis2.usescases.biometrics.BiometricConstantsKt.BIOMETRICS_VERIFICATION_STATUS;
 import static org.dhis2.usescases.eventsWithoutRegistration.eventInitial.EventInitialPresenter.ACCESS_LOCATION_PERMISSION_REQUEST;
 import static org.dhis2.utils.Constants.ENROLLMENT_UID;
 import static org.dhis2.utils.Constants.EVENT_CREATION_TYPE;
@@ -160,6 +164,9 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
     private Geometry newGeometry;
     private CoordinateViewModel currentGeometryModel;
     private GeometryController geometryController = new GeometryController(new GeometryParserImpl());
+    private String biometricsGuid;
+    private int verificationStatus;
+    private String teiOrgUnitUid;
 
     public static Bundle getBundle(String programUid, String eventUid, String eventCreationType,
                                    String teiUid, PeriodType eventPeriodType, String orgUnit, String stageUid,
@@ -178,6 +185,18 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
         return bundle;
     }
 
+    public static Bundle getBundleWithBiometrics(String programUid, String eventUid, String eventCreationType,
+            String teiUid, PeriodType eventPeriodType, String orgUnit, String stageUid,
+            String enrollmentUid, int eventScheduleInterval, EnrollmentStatus enrollmentStatus,
+            String biometricsGuid, int verificationStatus, String orgUnitUid) {
+        Bundle bundle =getBundle(programUid,eventUid,eventCreationType,teiUid,eventPeriodType,
+                orgUnit,stageUid,enrollmentUid,eventScheduleInterval,enrollmentStatus);
+        bundle.putString(BIOMETRICS_GUID, biometricsGuid);
+        bundle.putInt(BIOMETRICS_VERIFICATION_STATUS, verificationStatus);
+        bundle.putString(BIOMETRICS_TEI_ORGANISATION_UNIT, orgUnitUid);
+        return bundle;
+    }
+
     private void initVariables() {
         programUid = getIntent().getStringExtra(PROGRAM_UID);
         eventUid = getIntent().getStringExtra(Constants.EVENT_UID);
@@ -191,6 +210,10 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
         programStageUid = getIntent().getStringExtra(Constants.PROGRAM_STAGE_UID);
         enrollmentStatus = (EnrollmentStatus) getIntent().getSerializableExtra(Constants.ENROLLMENT_STATUS);
         eventScheduleInterval = getIntent().getIntExtra(Constants.EVENT_SCHEDULE_INTERVAL, 0);
+
+        biometricsGuid = getIntent().getStringExtra(BIOMETRICS_GUID);
+        verificationStatus = getIntent().getIntExtra(BIOMETRICS_VERIFICATION_STATUS, -1);
+        teiOrgUnitUid =getIntent().getStringExtra(BIOMETRICS_TEI_ORGANISATION_UNIT);
     }
 
     @Override
@@ -505,7 +528,8 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
     private void startFormActivity(String eventUid, boolean isNew) {
         Intent intent = new Intent(this, EventCaptureActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_FORWARD_RESULT);
-        intent.putExtras(EventCaptureActivity.getActivityBundle(eventUid, programUid, isNew ? EventMode.NEW : EventMode.CHECK));
+        intent.putExtras(EventCaptureActivity.getActivityBundleWithBiometrics(eventUid, programUid, isNew ? EventMode.NEW : EventMode.CHECK, biometricsGuid,
+        verificationStatus, teiOrgUnitUid));
         startActivity(intent);
         finish();
     }

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.java
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.java
@@ -76,6 +76,9 @@ import timber.log.Timber;
 import static android.app.Activity.RESULT_OK;
 import static com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions.withCrossFade;
 
+import static org.dhis2.usescases.biometrics.BiometricConstantsKt.BIOMETRICS_GUID;
+import static org.dhis2.usescases.biometrics.BiometricConstantsKt.BIOMETRICS_TEI_ORGANISATION_UNIT;
+import static org.dhis2.usescases.biometrics.BiometricConstantsKt.BIOMETRICS_VERIFICATION_STATUS;
 import static org.dhis2.usescases.biometrics.BiometricConstantsKt.BIOMETRICS_VERIFY_REQUEST;
 import static org.dhis2.utils.Constants.ENROLLMENT_UID;
 import static org.dhis2.utils.Constants.EVENT_CREATION_TYPE;
@@ -504,6 +507,11 @@ public class TEIDataFragment extends FragmentGlobalAbstract implements TEIDataCo
             bundle.putString(ENROLLMENT_UID, dashboardModel.getCurrentEnrollment().uid());
             bundle.putString(EVENT_CREATION_TYPE, eventCreationType.name());
             bundle.putInt(EVENT_SCHEDULE_INTERVAL, scheduleIntervalDays);
+
+            bundle.putString(BIOMETRICS_GUID, dashboardModel.getTrackedBiometricEntityValue());
+            bundle.putInt(BIOMETRICS_VERIFICATION_STATUS, -1);
+            bundle.putString(BIOMETRICS_TEI_ORGANISATION_UNIT, dashboardModel.getCurrentOrgUnit().uid());
+
             Intent intent = new Intent(getContext(), ProgramStageSelectionActivity.class);
             intent.putExtras(bundle);
             startActivityForResult(intent, REQ_EVENT);
@@ -638,6 +646,11 @@ public class TEIDataFragment extends FragmentGlobalAbstract implements TEIDataCo
         bundle.putSerializable(EVENT_PERIOD_TYPE, programStage.periodType());
         bundle.putString(Constants.PROGRAM_STAGE_UID, programStage.uid());
         bundle.putInt(EVENT_SCHEDULE_INTERVAL, programStage.standardInterval() != null ? programStage.standardInterval() : 0);
+
+        bundle.putString(BIOMETRICS_GUID, dashboardModel.getTrackedBiometricEntityValue());
+        bundle.putInt(BIOMETRICS_VERIFICATION_STATUS, -1);
+        bundle.putString(BIOMETRICS_TEI_ORGANISATION_UNIT, dashboardModel.getCurrentOrgUnit().uid());
+
         intent.putExtras(bundle);
         startActivityForResult(intent, REQ_EVENT);
     }

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataPresenterImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataPresenterImpl.java
@@ -407,13 +407,13 @@ public class TEIDataPresenterImpl implements TEIDataContracts.Presenter {
             Event event = d2.eventModule().events().uid(uid).blockingGet();
             ProgramStage stage = d2.programModule().programStages().uid(event.programStage()).blockingGet();
 
-            if(BIOMETRICS_ENABLED && guid!=null && stage.displayName().equalsIgnoreCase("Follow-up")) {
+/*            if(BIOMETRICS_ENABLED && guid!=null && stage.displayName().equalsIgnoreCase("Follow-up")) {
                 verifyingBeforeEnterEvent = true;
                 verifyBiometrics();
-            }else {
-                launchEventCapture(uid, null, -1);
+            }else {*/
+                launchEventCapture(uid, dashboardModel.getTrackedBiometricEntityValue(), -1);
 
-            }
+            //}
 
 /*            Intent intent = new Intent(view.getContext(), EventCaptureActivity.class);
             intent.putExtras(EventCaptureActivity.getActivityBundle(uid, programUid, EventMode.CHECK));
@@ -421,9 +421,12 @@ public class TEIDataPresenterImpl implements TEIDataContracts.Presenter {
         } else {
             Event event = d2.eventModule().events().uid(uid).blockingGet();
             Intent intent = new Intent(view.getContext(), EventInitialActivity.class);
-            intent.putExtras(EventInitialActivity.getBundle(
-                    programUid, uid, EventCreationType.DEFAULT.name(), teiUid, null, event.organisationUnit(), event.programStage(), dashboardModel.getCurrentEnrollment().uid(), 0, dashboardModel.getCurrentEnrollment().status()
+
+            intent.putExtras(EventInitialActivity.getBundleWithBiometrics(
+                    programUid, uid, EventCreationType.DEFAULT.name(), teiUid, null, event.organisationUnit(), event.programStage(), dashboardModel.getCurrentEnrollment().uid(), 0, dashboardModel.getCurrentEnrollment().status(),
+                    dashboardModel.getTrackedBiometricEntityValue(),-1,orgUnitUid
             ));
+
             view.openEventInitial(intent);
         }
     }
@@ -435,10 +438,7 @@ public class TEIDataPresenterImpl implements TEIDataContracts.Presenter {
         }
 
         Intent intent = new Intent(view.getContext(), EventCaptureActivity.class);
-        intent.putExtras(EventCaptureActivity.getActivityBundle(uid, programUid, EventMode.CHECK));
-        intent.putExtra(BIOMETRICS_GUID, guid);
-        intent.putExtra(BIOMETRICS_VERIFICATION_STATUS, status);
-        intent.putExtra(BIOMETRICS_TEI_ORGANISATION_UNIT, orgUnitUid);
+        intent.putExtras(EventCaptureActivity.getActivityBundleWithBiometrics(uid, programUid, EventMode.CHECK,guid,status,orgUnitUid));
         view.openEventCapture(intent);
     }
 
@@ -450,7 +450,7 @@ public class TEIDataPresenterImpl implements TEIDataContracts.Presenter {
 
     @Override
     public void handleVerifyResponse(VerifyResult result) {
-        if (verifyingBeforeEnterEvent){
+/*        if (verifyingBeforeEnterEvent){
             verifyingBeforeEnterEvent = false;
             if (result instanceof VerifyResult.Match){
                 launchEventCapture(null, dashboardModel.getTrackedBiometricEntityValue(), 1);
@@ -459,7 +459,7 @@ public class TEIDataPresenterImpl implements TEIDataContracts.Presenter {
             } else if (result instanceof VerifyResult.Failure){
                 launchEventCapture(null, dashboardModel.getTrackedBiometricEntityValue(), 0);
             }
-        } else{
+        } else{*/
             if (result instanceof VerifyResult.Match){
                 view.verificationStatusMatch();
             } else if (result instanceof VerifyResult.NoMatch){
@@ -467,7 +467,7 @@ public class TEIDataPresenterImpl implements TEIDataContracts.Presenter {
             } else {
                 view.verificationStatusFailed();
             }
-        }
+       // }
     }
 
     @Override


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/1dnn3kw
* **Related Pull request:**  

###   :gear: branches 
**app**: 
       Origin:feature/verify_in_event_if_biometrics_DE_exista Target: develop-simprints
**dhis2-android-SDK**: 
       Origin: develop_eyeseetea
**dhis2-rule-engine**: 
       Origin: ec2b39f051acd5f1a28b2cf940e83176857f4d76
### :tophat: What is the goal?

Enable verification to enter in the event by data element biometrics

### :memo: How is it being implemented?

- [x] Enable verification to enter in the event by data element biometrics

**Important**: To show the biometrics check successfully in the TEI dashboards, the tracked entity attribute for the program must to be displayed in list check marked. I have marked for 1.2 Antenatal Care program. we should marked for all programs where this attribute exists and push the docker image

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-