### PR TITLE
Simprints - Wait until confirm identity response to enter in TEI

### DIFF
--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2021-09-02 14:39","gitSha":"41db67fe0"}
+{"buildTime":"2021-09-02 15:41","gitSha":"faf10c5b5"}

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEContractsModule.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEContractsModule.java
@@ -1,7 +1,6 @@
 package org.dhis2.usescases.searchTrackEntity;
 
 import android.graphics.drawable.Drawable;
-import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -96,7 +95,8 @@ public class SearchTEContractsModule {
 
         void hideFilter();
 
-        void sendBiometricsConfirmIdentity(String sessionId, String guid);
+        void sendBiometricsConfirmIdentity(String sessionId, String guid, String teiUid,
+                String enrollmentUid, boolean isOnline);
         void sendBiometricsNoneSelected(String sessionId);
         void biometricsEnrollmentLast(String sessionId);
 

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
@@ -812,19 +812,17 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
     @Override
     public void onTEIClick(String TEIuid, String enrollmentUid, boolean isOnline) {
         if(biometricsSearchStatus){
-            sendBiometricsConfirmIdentity(TEIuid);
-        }
-
-        if (!isOnline) {
+            sendBiometricsConfirmIdentity(TEIuid, enrollmentUid, isOnline);
             biometricsSearchStatus = false;
-            openDashboard(TEIuid, enrollmentUid);
         } else {
-            biometricsSearchStatus = false;
-            downloadTei(TEIuid, enrollmentUid);
+            if (!isOnline) {
+                openDashboard(TEIuid, enrollmentUid);
+            } else {
+                downloadTei(TEIuid, enrollmentUid);
+            }
         }
     }
-
-    private void sendBiometricsConfirmIdentity(String teiUid) {
+    private void sendBiometricsConfirmIdentity(String teiUid, String enrollmentUid, boolean isOnline) {
         if (sessionId != null) {
             TrackedEntityInstance tei =
                     d2.trackedEntityModule().trackedEntityInstances()
@@ -834,7 +832,7 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
 
             view.hideNoneOfTheAboveButton();
             view.hideIdentificationPlusButton();
-            view.sendBiometricsConfirmIdentity(sessionId, guid);
+            view.sendBiometricsConfirmIdentity(sessionId, guid, teiUid, enrollmentUid, isOnline);
         }
     }
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** 
https://app.clickup.com/t/1dnmx0z
https://app.clickup.com/t/1dnmx3d
* **Related Pull request:**  

###   :gear: branches 
**app**: 
       feature/wait_to_confirm_identity_to_navigate_to_tei Target: develop-simprints
**dhis2-android-SDK**: 
       Origin: develop_eyeseetea
**dhis2-rule-engine**: 
       Origin: ec2b39f051acd5f1a28b2cf940e83176857f4d76
### :tophat: What is the goal?

Wait to confirm identity response to enter in TEI dashboard 

### :memo: How is it being implemented?

- [x] Wait to confirm identity response to enter in TEI dashboard 

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.