### PR TITLE
Simprints - Show enroll last buttonwhen exist search results

### DIFF
--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2021-10-04 10:11","gitSha":"cb337f300"}
+{"buildTime":"2021-10-11 07:55","gitSha":"ff3cfd48f"}

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.java
@@ -711,11 +711,10 @@ public class SearchTEActivity extends ActivityGlobalAbstract implements SearchTE
 
                     if (searchTeiModels.size() > 0){
                         showNoneOfTheAboveButton();
-                        hideIdentificationPlusButton();
                     } else {
                         hideNoneOfTheAboveButton();
-                        showIdentificationPlusButton();
                     }
+                    showIdentificationPlusButton();
 
                     for(int i = 0; i < searchTeiModels.size(); i++){
                         searchTeiModels.get(i).setBiometricsSearchStatus(true);


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/1gprgej
* **Related Pull request:**  

###   :gear: branches 
**app**: 
       Origin:feature/show_last_biometrics_with_search_results Target: develop-simprints
**dhis2-android-SDK**: 
       Origin: develop_eyeseetea
**dhis2-rule-engine**: 
       Origin: ec2b39f051acd5f1a28b2cf940e83176857f4d76
### :tophat: What is the goal?

Show enroll last button when exists search results

### :memo: How is it being implemented?

- [x] Show enroll last button when exists search results

### :boom: How can it be tested?

**use case 1** - Search an existed TEI by face and should show the results, the none of above button and enroll last button
**use case 2** -  Enroll last should work when is showing after found search results

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

