### PR TITLE
Simprints - Hide none of above to click on enroll last

### DIFF
--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2021-10-20 15:05","gitSha":"244ec5f42"}
+{"buildTime":"2021-10-20 16:15","gitSha":"e99b36a82"}

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
@@ -1141,6 +1141,7 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
         if(biometricsSearchStatus){
             view.hideIdentificationPlusButton();
             biometricsSearchStatus = false;
+            view.hideNoneOfTheAboveButton();
             view.biometricsEnrollmentLast(sessionId);
         }
     }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/1hkb645
* **Related Pull request:**  

###   :gear: branches 
**app**: 
       Origin:feature/simprints_hide_none_of_the_above_after_enroll_last Target: develop-simprints
**dhis2-android-SDK**: 
       Origin: develop_eyeseetea
**dhis2-rule-engine**: 
       Origin: ec2b39f051acd5f1a28b2cf940e83176857f4d76
### :tophat: What is the goal?

Simprints hide none of the above after enroll last

### :memo: How is it being implemented?

- [x] Simprints hide none of the above after enroll last

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
