### PR TITLE
Simprints - maintain verify button green while last verification duration

### DIFF
--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2021-10-25 11:40","gitSha":"3102802dc"}
+{"buildTime":"2021-10-26 10:42","gitSha":"ffc545fe7"}

--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2021-10-25 10:40","gitSha":"eaf76f343"}
+{"buildTime":"2021-10-25 11:40","gitSha":"3102802dc"}

--- a/app/src/main/java/org/dhis2/usescases/biometrics/Verification.kt
+++ b/app/src/main/java/org/dhis2/usescases/biometrics/Verification.kt
@@ -1,0 +1,24 @@
+package org.dhis2.usescases.biometrics
+
+import timber.log.Timber
+import java.util.Date
+import java.util.concurrent.TimeUnit
+
+fun isLastVerificationValid(lastVerification: Date?, maxDuration: Int = 0, trace:Boolean): Boolean {
+
+    var lastUpdatedMinutes: Long? = null
+
+    if (lastVerification != null) {
+        lastUpdatedMinutes = TimeUnit.MILLISECONDS.toMinutes(
+            Date().time - lastVerification.time
+        )
+    }
+
+    if (trace){
+        Timber.d("lastBiometricsVerificationDuration $maxDuration")
+        Timber.d("Biometrics last updated date $lastVerification")
+        Timber.d("Biometrics last updated minutes $lastUpdatedMinutes")
+    }
+
+    return lastUpdatedMinutes != null && lastUpdatedMinutes <= maxDuration
+}

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/eventCaptureFragment/EventCaptureFormFragment.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/eventCaptureFragment/EventCaptureFormFragment.java
@@ -165,11 +165,11 @@ public class EventCaptureFormFragment extends FragmentGlobalAbstract implements 
                             this.getContext()).handleVerifyResponse(data);
 
                     if (result instanceof VerifyResult.Match) {
-                        presenter.refreshBiometricsVerificationStatus(1);
+                        presenter.refreshBiometricsVerificationStatus(1,true);
                     } else if (result instanceof VerifyResult.NoMatch) {
-                        presenter.refreshBiometricsVerificationStatus(0);
+                        presenter.refreshBiometricsVerificationStatus(0,true);
                     } else if (result instanceof VerifyResult.Failure) {
-                        presenter.refreshBiometricsVerificationStatus(0);
+                        presenter.refreshBiometricsVerificationStatus(0,true);
                     }
                 }
                 break;

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/eventCaptureFragment/EventCaptureFormPresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/eventCaptureFragment/EventCaptureFormPresenter.kt
@@ -139,6 +139,8 @@ class EventCaptureFormPresenter(
 
             if (lastUpdatedMinutes == null || lastUpdatedMinutes >= activityPresenter.lastBiometricsVerificationDuration) {
                 view.verifyBiometrics(this.biometricsGuid, this.teiOrgUnit)
+            } else {
+                refreshBiometricsVerificationStatus(1)
             }
         }
     }

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/DashboardProgramModel.java
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/DashboardProgramModel.java
@@ -12,6 +12,7 @@ import org.hisp.dhis.android.core.organisationunit.OrganisationUnit;
 import org.hisp.dhis.android.core.program.Program;
 import org.hisp.dhis.android.core.program.ProgramStage;
 import org.hisp.dhis.android.core.program.ProgramTrackedEntityAttribute;
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeValue;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance;
 
@@ -129,6 +130,10 @@ public class DashboardProgramModel extends BaseObservable {
         return trackedEntityAttributeValues;
     }
 
+    public void updateTrackedEntityAttributeValues(List<TrackedEntityAttributeValue> values){
+        trackedEntityAttributeValues = values;
+    }
+
     public Enrollment getEnrollmentForProgram(String uid) {
         for (Enrollment enrollment : teiEnrollments)
             if (Objects.equals(enrollment.program(), uid))
@@ -194,5 +199,23 @@ public class DashboardProgramModel extends BaseObservable {
         }
 
         return biometricUid;
+    }
+
+    public TrackedEntityAttributeValue getTrackedBiometricEntityAttributeValue(){
+        String biometricUid = getTrackedBiometricEntityAttributeUid();
+
+        if(biometricUid != null){
+            for(TrackedEntityAttributeValue value: trackedEntityAttributeValues){
+                if(biometricUid.equalsIgnoreCase(value.trackedEntityAttribute())){
+                    if(value==null || value.value().isEmpty()){
+                        return null;
+                    }else{
+                        return value;
+                    }
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataContracts.java
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataContracts.java
@@ -88,6 +88,8 @@ public class TEIDataContracts {
 
         void launchBiometricsVerification(String guid, String orgUnitUid);
 
+        void resetVerificationStatus();
+
         void verificationStatusMatch();
 
         void verificationStatusNoMatch();

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.java
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.java
@@ -237,6 +237,18 @@ public class TEIDataFragment extends FragmentGlobalAbstract implements TEIDataCo
     }
 
     @Override
+    public void resetVerificationStatus() {
+        binding.cardFront.verificationButton.setBackground(ContextCompat.getDrawable(context,
+                R.drawable.button_round_2
+        ));
+
+        binding.cardFront.verificationButtonText.setText(R.string.biometrics_verification_not_done);
+
+        binding.cardFront.verificationButtonIcon.setImageDrawable(
+                AppCompatResources.getDrawable(context, getBioIconSuccess(context)));
+    }
+
+    @Override
     public void verificationStatusMatch() {
         binding.cardFront.verificationButton.setBackground(ContextCompat.getDrawable(context,
                 R.drawable.button_round_success

--- a/app/src/test/java/org/dhis2/usescases/biometrics/VerificationTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/biometrics/VerificationTest.kt
@@ -1,0 +1,32 @@
+package org.dhis2.usescases.biometrics
+
+import org.junit.Assert
+import org.junit.Test
+import java.util.Date
+
+class VerificationTest {
+    private val maxDuration = 30
+
+    @Test
+    fun `Should return is valid if last verification time is lower than max duration`() {
+        val lastVerification = givenADatePreviousFromNow(maxDuration - 1)
+        Assert.assertTrue(isLastVerificationValid(lastVerification, maxDuration))
+    }
+
+    @Test
+    fun `Should return is valid if last verification time is equal to max duration`() {
+        val lastVerification = givenADatePreviousFromNow(maxDuration)
+        Assert.assertTrue(isLastVerificationValid(lastVerification, maxDuration))
+    }
+
+    @Test
+    fun `Should return is not valid if last verification time greater than to max duration`() {
+        val lastVerification = givenADatePreviousFromNow(maxDuration + 1)
+        Assert.assertFalse(isLastVerificationValid(lastVerification, maxDuration))
+    }
+
+    private fun givenADatePreviousFromNow(minutes: Int): Date {
+        val timeInSecs: Long = Date().time
+        return Date(timeInSecs - minutes * 60 * 1000)
+    }
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/1ht3qfq
* **Related Pull request:**  

###   :gear: branches 
**app**: 
       Origin: feature/maintain_verify_button_green_until_verification_duration Target: develop-simprints
**dhis2-android-SDK**: 
       Origin: develop_eyeseetea
**dhis2-rule-engine**: 
       Origin: ec2b39f051acd5f1a28b2cf940e83176857f4d76
### :tophat: What is the goal?

Maintain verify button green while last verification duration is valid

### :memo: How is it being implemented?

- [x] Call to confirm identity to click on a possible duplicate

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

