### PR TITLE
Simprints - Allow multiple projects

### DIFF
--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2022-03-10 09:35","gitSha":"0d532452c"}
+{"buildTime":"2022-03-11 06:48","gitSha":"75aaa87aa"}

--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2022-03-11 06:48","gitSha":"75aaa87aa"}
+{"buildTime":"2022-03-11 11:55","gitSha":"2ebbcfba9"}

--- a/app/src/main/java/org/dhis2/data/biometrics/BiometricsConfigApi.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/BiometricsConfigApi.kt
@@ -6,5 +6,5 @@ import retrofit2.http.GET
 
 interface BiometricsConfigApi {
     @GET("dataStore/simprints/config")
-    fun getData(): Call<BiometricsConfig>
+    fun getData(): Call<List<BiometricsConfig>>
 }

--- a/app/src/main/java/org/dhis2/data/biometrics/BiometricsConfigRepositoryImpl.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/BiometricsConfigRepositoryImpl.kt
@@ -15,7 +15,8 @@ class BiometricsConfigRepositoryImpl(
         try {
             val response = biometricsConfigApi.getData().execute()
 
-            val config = response.body()
+            val configOptions = response.body()
+            val config = configOptions?.find { it.orgUnitGroup.toLowerCase() == "default" }
 
             if (response.isSuccessful && config != null) {
 

--- a/app/src/main/java/org/dhis2/data/service/ReservedValuesWorkerModule.java
+++ b/app/src/main/java/org/dhis2/data/service/ReservedValuesWorkerModule.java
@@ -34,7 +34,7 @@ public class ReservedValuesWorkerModule {
             @NonNull PreferenceProvider preferences
     ) {
         BiometricsConfigApi biometricsConfigApi = d2.retrofit().create(BiometricsConfigApi.class);
-        return new BiometricsConfigRepositoryImpl(preferences, biometricsConfigApi);
+        return new BiometricsConfigRepositoryImpl(d2, preferences, biometricsConfigApi);
     }
 
     @Provides

--- a/app/src/main/java/org/dhis2/data/service/ServiceModule.java
+++ b/app/src/main/java/org/dhis2/data/service/ServiceModule.java
@@ -34,7 +34,7 @@ public class ServiceModule {
             @NonNull PreferenceProvider preferences
     ) {
         BiometricsConfigApi biometricsConfigApi = d2.retrofit().create(BiometricsConfigApi.class);
-        return new BiometricsConfigRepositoryImpl(preferences, biometricsConfigApi);
+        return new BiometricsConfigRepositoryImpl(d2, preferences, biometricsConfigApi);
     }
 
     @Provides

--- a/app/src/main/java/org/dhis2/data/service/SyncDataWorkerModule.java
+++ b/app/src/main/java/org/dhis2/data/service/SyncDataWorkerModule.java
@@ -25,7 +25,7 @@ public class SyncDataWorkerModule {
             @NonNull PreferenceProvider preferences
     ) {
         BiometricsConfigApi biometricsConfigApi = d2.retrofit().create(BiometricsConfigApi.class);
-        return new BiometricsConfigRepositoryImpl(preferences, biometricsConfigApi);
+        return new BiometricsConfigRepositoryImpl(d2, preferences, biometricsConfigApi);
     }
 
     @Provides

--- a/app/src/main/java/org/dhis2/data/service/SyncGranularRxModule.java
+++ b/app/src/main/java/org/dhis2/data/service/SyncGranularRxModule.java
@@ -25,7 +25,7 @@ public class SyncGranularRxModule {
             @NonNull PreferenceProvider preferences
     ) {
         BiometricsConfigApi biometricsConfigApi = d2.retrofit().create(BiometricsConfigApi.class);
-        return new BiometricsConfigRepositoryImpl(preferences, biometricsConfigApi);
+        return new BiometricsConfigRepositoryImpl(d2, preferences, biometricsConfigApi);
     }
 
     @Provides

--- a/app/src/main/java/org/dhis2/data/service/SyncInitWorkerModule.java
+++ b/app/src/main/java/org/dhis2/data/service/SyncInitWorkerModule.java
@@ -25,7 +25,7 @@ public class SyncInitWorkerModule {
             @NonNull PreferenceProvider preferences
     ) {
         BiometricsConfigApi biometricsConfigApi = d2.retrofit().create(BiometricsConfigApi.class);
-        return new BiometricsConfigRepositoryImpl(preferences, biometricsConfigApi);
+        return new BiometricsConfigRepositoryImpl(d2, preferences, biometricsConfigApi);
     }
 
     @Provides

--- a/app/src/main/java/org/dhis2/data/service/SyncMetadataWorkerModule.java
+++ b/app/src/main/java/org/dhis2/data/service/SyncMetadataWorkerModule.java
@@ -25,7 +25,7 @@ public class SyncMetadataWorkerModule {
             @NonNull PreferenceProvider preferences
     ) {
         BiometricsConfigApi biometricsConfigApi = d2.retrofit().create(BiometricsConfigApi.class);
-        return new BiometricsConfigRepositoryImpl(preferences, biometricsConfigApi);
+        return new BiometricsConfigRepositoryImpl(d2, preferences, biometricsConfigApi);
     }
 
     @Provides

--- a/app/src/main/java/org/dhis2/usescases/biometrics/BiometricsConfig.kt
+++ b/app/src/main/java/org/dhis2/usescases/biometrics/BiometricsConfig.kt
@@ -1,6 +1,7 @@
 package org.dhis2.usescases.biometrics
 
 data class BiometricsConfig(
+    val orgUnitGroup: String,
     val projectId: String,
     val confidenceScoreFilter: Int?,
     val icon: String?,


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/221ybk6

###   :gear: branches 
**app**: 
       Origin: feature/simprints_multiple_projects Target: develop-simprints
**dhis2-android-SDK**: 
       Origin: feature/bring_last_changes_1_5
**dhis2-rule-engine**: 
       Origin: 1487217e436fca74141eb4af7d01076eea4a93be
### :tophat: What is the goal?

Allow multiple project options in biometrics config in the data store.

### :memo: How is it being implemented?

- [x] Adding orgUnitGroup to config and list as response

### :boom: How can it be tested?

According to this data store config

```json
[
  {
    "orgUnitGroup": "default",
    "icon": "face",
    "projectId": "Ma9wi0IBdo215PKRXOf5",
    "confidenceScoreFilter": 10,
    "lastVerificationDuration": 1  
  },
   {
     "orgUnitGroup": "WxOBP52iOBB",
    "icon": "fingerprint",
    "projectId": "Ma9wi0IBdo215PKRXOf5",
    "confidenceScoreFilter": 10,
    "lastVerificationDuration": 1  
  },
   {
     "orgUnitGroup": "AmXZgWi8oRE",
    "icon": "face",
    "projectId": "Ma9wi0IBdo215PKRXOf6",
    "confidenceScoreFilter": 20,
    "lastVerificationDuration": 2  
  }
  ]
```

**Use case 1**: 
Edit admin user to set access only to next org units:  
* Asafo-Akrodie CHPS (MDKFlDiQ7Er)
* Akrodie Health Centre (PzO3UvH7za0)

Login using admin user or refresh configuration and the selected config should be default because these orgUnits belong to 4 org unit groups.
You can review the selected config in log filtering by 'bio' text.

**Use case 2**: 
Edit admin user to set access only to next org units:  
* Mim Central CHPS (waBg6K7X0nU)
* Nana Bofah CHPS (xJclaoPVPdj)

Login using admin user or refresh configuration and the selected config should be WxOBP52iOBB because these orgUnits belong to 1 org unit group (WxOBP52iOBB).
You can review the selected config in log filtering by 'bio' text.

**Use case 3**: 
Edit admin user to set access only to next org units:  
* Kamirekrom CHPS (RvJufBX9rD1)

Login using admin user or refresh configuration and the selected config should be default because these orgUnits belong to 0 org unit group 
You can review the selected config in log filtering by 'bio' text.

**Use case 4**: 
Edit admin user to set access only to next org units:  
* Asafo-Akrodie CHPS (MDKFlDiQ7Er). 

Login using admin user or refresh configuration and the selected config should be default because these orgUnits belong to 1 org unit group (WxOBP52iOBB) but this org unit group is not configured in the data store.
You can review the selected config in log filtering by 'bio' text.


### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-