### PR TITLE
Simprints - block biometrics retake button

### DIFF
--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2022-03-14 10:22","gitSha":"257f38eef"}
+{"buildTime":"2022-03-14 12:18","gitSha":"beb049bde"}

--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2022-03-11 11:55","gitSha":"2ebbcfba9"}
+{"buildTime":"2022-03-14 10:22","gitSha":"257f38eef"}

--- a/app/src/main/java/org/dhis2/data/forms/dataentry/fields/biometrics/BiometricsView.java
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/fields/biometrics/BiometricsView.java
@@ -11,6 +11,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
+import android.view.View;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -30,6 +31,7 @@ public class BiometricsView extends FieldLayout {
     private BiometricsViewModel viewModel;
 
     LinearLayout biometricsButton;
+    LinearLayout retakeButton;
     TextView biometricsButtonText;
     ImageView biometricsButtonIcon;
     LinearLayout rootView;
@@ -60,10 +62,17 @@ public class BiometricsView extends FieldLayout {
 
         rootView = findViewById(R.id.rootView);
         biometricsButton = findViewById(R.id.biometrics_button);
+        retakeButton = findViewById(R.id.biometrics_retake_button);
         biometricsButtonText = findViewById(R.id.biometrics_button_text);
         biometricsButtonIcon = findViewById(R.id.biometrics_button_icon);
 
         biometricsButton.setOnClickListener(v -> {
+            if (viewModel != null) {
+                viewModel.onBiometricsClick();
+            }
+        });
+
+        retakeButton.setOnClickListener(v -> {
             if (viewModel != null) {
                 viewModel.onBiometricsClick();
             }
@@ -95,16 +104,21 @@ public class BiometricsView extends FieldLayout {
     }
 
     void onInitial() {
+        retakeButton.setVisibility(View.GONE);
+        biometricsButton.setEnabled(true);
         biometricsButtonIcon.setImageDrawable(
                 AppCompatResources.getDrawable(rootView.getContext(),
                         getBioIconNew(rootView.getContext())));
     }
 
     void onSuccess() {
+        retakeButton.setVisibility(View.VISIBLE);
         biometricsButton.setBackground(ContextCompat.getDrawable(
                 rootView.getContext(),
                 R.drawable.button_round_success
         ));
+
+        biometricsButton.setEnabled(false);
 
         biometricsButtonText.setText(R.string.biometrics_completed);
 
@@ -114,10 +128,13 @@ public class BiometricsView extends FieldLayout {
     }
 
     void onFailure() {
+        retakeButton.setVisibility(View.VISIBLE);
         biometricsButton.setBackground(ContextCompat.getDrawable(
                 rootView.getContext(),
                 R.drawable.button_round_warning
         ));
+
+        biometricsButton.setEnabled(false);
 
         biometricsButtonText.setText(R.string.biometrics_declined);
 

--- a/app/src/main/java/org/dhis2/data/forms/dataentry/fields/biometrics/BiometricsView.java
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/fields/biometrics/BiometricsView.java
@@ -90,7 +90,7 @@ public class BiometricsView extends FieldLayout {
         Timber.tag("BiometricsView value").d(value);
 
         if (value != null && value.length() > 0) {
-            if (value.equalsIgnoreCase(BIOMETRICS_FAILURE_PATTERN)) {
+            if (value.startsWith(BIOMETRICS_FAILURE_PATTERN)) {
                 Timber.tag("BiometricsView").d("onFailure");
                 onFailure();
             } else {

--- a/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentPresenterImpl.kt
+++ b/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentPresenterImpl.kt
@@ -48,6 +48,7 @@ import org.hisp.dhis.android.core.program.Program
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceObjectRepository
 import org.hisp.dhis.rules.models.RuleEffect
 import timber.log.Timber
+import java.util.UUID
 
 private const val TAG = "EnrollmentPresenter"
 
@@ -537,18 +538,21 @@ class EnrollmentPresenterImpl(
     }
 
     fun onBiometricsFailure() {
-        saveBiometricValue(BIOMETRICS_FAILURE_PATTERN)
+        val uuid: UUID = UUID.randomUUID()
+        saveBiometricValue("${BIOMETRICS_FAILURE_PATTERN}_${uuid}")
     }
 
     private fun checkIfBiometricValueValid() {
 
-        if (biometricsViewModel != null && biometricsViewModel!!.value().equals(BIOMETRICS_FAILURE_PATTERN)) {
+        if (biometricsViewModel != null && biometricsViewModel!!.value() != null &&
+            biometricsViewModel!!.value()!!.startsWith(BIOMETRICS_FAILURE_PATTERN)
+        ) {
             valueStore.save(biometricsViewModel!!.uid(), null).blockingFirst()
         }
     }
 
     private fun saveBiometricValue(value: String) {
-        if(biometricsViewModel != null) {
+        if (biometricsViewModel != null) {
             valueStore.save(biometricsViewModel!!.uid(), value).blockingFirst()
             updateFields()
         }

--- a/app/src/main/res/layout/biometrics_view.xml
+++ b/app/src/main/res/layout/biometrics_view.xml
@@ -20,7 +20,7 @@
 
     <LinearLayout
         android:id="@+id/rootView"
-        android:orientation="vertical"
+        android:orientation="horizontal"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:padding="16dp">
@@ -28,8 +28,9 @@
         <LinearLayout
             android:id="@+id/biometrics_button"
             style="@style/ButtonRoundedGrey"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="0.7"
             android:padding="8dp"
             android:gravity="center">
 
@@ -53,6 +54,45 @@
                 android:textColor="@color/white"
                 android:textSize="12sp" />
         </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/biometrics_retake_button"
+            style="@style/ButtonRoundedGrey"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_weight="0.3"
+            android:gravity="center"
+            android:padding="8dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:visibility="gone">
+
+            <ImageView
+                android:id="@+id/verification_button_icon"
+                android:layout_width="27dp"
+                android:layout_height="27dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/ic_bio_retry"
+                tools:ignore="ContentDescription" />
+
+            <TextView
+                android:id="@+id/verification_button_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="6dp"
+                android:fontFamily="@font/rubik_medium"
+                android:text="@string/biometrics_retake"
+                android:textAllCaps="true"
+                android:textColor="@color/white"
+                android:textSize="12sp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@id/viewMoreIcon"
+                app:layout_constraintTop_toTopOf="parent" />
+        </LinearLayout>
+
     </LinearLayout>
 
 </layout>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -869,5 +869,6 @@
     <string name="biometrics_verification_match">Exitosa</string>
     <string name="biometrics_verification_no_match">Fallido</string>
     <string name="biometrics_verification_failed">Declinada</string>
+    <string name="biometrics_retake">Repetir</string>
     <!--endregion-->
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -517,5 +517,6 @@
     <string name="biometrics_verification_match">Succès</string>
     <string name="biometrics_verification_no_match">Échec</string>
     <string name="biometrics_verification_failed">Refusé</string>
+    <string name="biometrics_retake">Reprendre</string>
     <!--endregion-->
     </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -892,5 +892,6 @@
     <string name="biometrics_enroll_new">Enroll new</string>
     <string name="biometrics_possible_duplicates">Possible duplicates</string>
     <string name="biometrics_duplicates_empty_message">The search by possible duplicate guids returned by Simprints ID didn\'t return any result in Data Capture App.</string>
+    <string name="biometrics_retake">Retake</string>
     <!--endregion-->
 </resources>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/221

###   :gear: branches 
**app**: 
       Origin: feature/simprints_block_biometrics_retake_button Target: develop-simprints
**dhis2-android-SDK**: 
       Origin: feature/bring_last_changes_1_5
**dhis2-rule-engine**: 
       Origin: 1487217e436fca74141eb4af7d01076eea4a93be
### :tophat: What is the goal?

Block biometrics capture and retake biometrics button

### :memo: How is it being implemented?

- [x] Add retake button
- [x] Fix bug when biometrics failed

### :boom: How can it be tested?

**Use case 1**:  After successful biometrics register, the button should appear green and disabled and another retake button should appear.
**Use case 2**:  After failed biometrics register, the button should appear orange and disabled and another retake button should appear.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-