### PR TITLE
Simprints - Fix assign default config

### DIFF
--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2022-04-13 10:43","gitSha":"f4272dbbe"}
+{"buildTime":"2022-04-13 12:27","gitSha":"9536e0269"}

--- a/app/src/main/java/org/dhis2/data/biometrics/BiometricsConfigRepositoryImpl.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/BiometricsConfigRepositoryImpl.kt
@@ -56,7 +56,7 @@ class BiometricsConfigRepositoryImpl(
     }
 
     private fun getSelectedConfig(configOptions: List<BiometricsConfig>): BiometricsConfig {
-        val organisationUnitGroups =
+        val userOrgUnitGroups =
             d2.organisationUnitModule().organisationUnits()
                 .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
                 .withOrganisationUnitGroups()
@@ -65,6 +65,9 @@ class BiometricsConfigRepositoryImpl(
                         .map { ouGroup -> ouGroup.uid() }
                     else listOf()
                 }.distinct()
+
+        val userOrgUnitGroupsInConfig =
+            userOrgUnitGroups.filter{ouGroup -> configOptions.any{config -> config.orgUnitGroup == ouGroup}}
 
         val defaultConfig =
             configOptions.find { it.orgUnitGroup.toLowerCase() == "default" }
@@ -75,8 +78,8 @@ class BiometricsConfigRepositoryImpl(
             throw Exception(error)
         }
 
-        return if (organisationUnitGroups.size != 1) defaultConfig else
-            configOptions.find { it.orgUnitGroup == organisationUnitGroups[0] }
+        return if (userOrgUnitGroupsInConfig.size != 1) defaultConfig else
+            configOptions.find { it.orgUnitGroup == userOrgUnitGroupsInConfig[0] }
                 ?: defaultConfig
     }
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/26b6x5w

###   :gear: branches 
**app**: 
       Origin: fix/assign_default_config Target: develop-simprints
**dhis2-android-SDK**: 
       Origin: develop_eyeseetea
**dhis2-rule-engine**: 
       Origin: 1487217e436fca74141eb4af7d01076eea4a93be
### :tophat: What is the goal?

Fix assign default biometrics client when the user is assigned to two org unit groups but only one is configured in the data store

### :memo: How is it being implemented?

- [x] Does not assign default biometrics config if the user is assigned to two org unit groups but only one is configured in the datastore

### :boom: How can it be tested?


### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-