### PR TITLE
PSI - Fix fab overlaps with arrows in feedback

### DIFF
--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2022-04-12 15:06","gitSha":"23024191e"}
+{"buildTime":"2022-04-28 08:14","gitSha":"dad12cff2"}

--- a/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/FeedbackHelpItemBinder.kt
+++ b/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/FeedbackHelpItemBinder.kt
@@ -29,11 +29,22 @@ class FeedbackHelpItemBinder : TreeAdapterBinder(FeedbackHelpItem::class.java) {
 
             refreshShowingAll(holder, feedbackHelpItem)
 
+            helpText.setOnClickListener {
+                expandOrCollapse(holder, feedbackHelpItem)
+            }
+
             arrow.setOnClickListener {
-                feedbackHelpItem.showingAll = !feedbackHelpItem.showingAll
-                refreshShowingAll(holder, feedbackHelpItem)
+                expandOrCollapse(holder, feedbackHelpItem)
             }
         }
+    }
+
+    private fun expandOrCollapse(
+        holder: RecyclerView.ViewHolder,
+        feedbackHelpItem: FeedbackHelpItem
+    ) {
+        feedbackHelpItem.showingAll = !feedbackHelpItem.showingAll
+        refreshShowingAll(holder, feedbackHelpItem)
     }
 
     private fun refreshShowingAll(

--- a/app/src/psi/res/layout/fragment_feedback_content.xml
+++ b/app/src/psi/res/layout/fragment_feedback_content.xml
@@ -34,7 +34,9 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/failed_check_box"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            tools:listitem="@layout/item_feedback" />
+            tools:listitem="@layout/item_feedback"
+            android:paddingBottom="72dp"
+            android:clipToPadding="false"/>
 
         <TextView
             android:id="@+id/msg_feedback"


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/28zt9qh
* **Related Pull request:**  

###   :gear: branches 
**app**: 
       Origin: fix/fab_overlaps_with_arrows Target: develop-psi
**dhis2-android-SDK**: 
       Origin: develop-eyeseetea
**dhis2-rule-engine**: 
       Origin: 1487217e436fca74141eb4af7d01076eea4a93be
### :tophat: What is the goal?

Create a new flavor for Operation Christmas Child - Samaritan's Purse

### :memo: How is it being implemented?

- [x] Review parent items to expand to click on the row
- [x] Expand the help item to click on text and arrow
- [x] Add bottom padding with clipToPadding. With this feature the bottom padding only is active when you are at end the end of the scroll. [Video](https://user-images.githubusercontent.com/5593590/165689850-70743c54-4278-4419-998d-d92eff485a52.mp4)

### :boom: How can it be tested?

**use case 1**:  All items should expand to click on the row
**use case 2**: When you scroll at the end the fab button does not overlap

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-





