### PR TITLE
PSI - Avoid show in feedback values with null

### DIFF
--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2022-04-28 08:14","gitSha":"dad12cff2"}
+{"buildTime":"2022-04-28 12:34","gitSha":"a22f6511d"}

--- a/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/ValuesD2Repository.kt
+++ b/app/src/psi/java/org/dhis2/usescases/teiDashboard/dashboardsfragments/feedback/ValuesD2Repository.kt
@@ -35,7 +35,7 @@ class ValuesD2Repository(
 
         val teiDataValues =
             d2.trackedEntityModule().trackedEntityDataValues().byEvent().eq(eventUid)
-                .get().blockingGet()
+                .get().blockingGet().filter { it.value() != null }
 
         val dataElementsWithFeedbackOrder =
             getDataElementsWithFeedbackOrder(feedbackOrderAttributeCode)


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/28ztan4
* **Related Pull request:**  

###   :gear: branches 
**app**: 
       Origin: :fix/avoid_show_null_data_values_in_feedback Target: develop-psi
**dhis2-android-SDK**: 
       Origin: develop-eyeseetea
**dhis2-rule-engine**: 
       Origin: 1487217e436fca74141eb4af7d01076eea4a93be
### :tophat: What is the goal?

Fix empty items in the feedback

### :memo: How is it being implemented?

- [x] Avoid show in feedback values with null

### :boom: How can it be tested?

To Reproduce
Credentials
Server: https://236dev.psi-mis.org/
User: hnqis2.fork
Password: Solar123!

Steps to reproduce the behavior:

* Go to HNQIS2 Fork Testing Program
* Make a new enrollmetn
* Add an Assessment stage
* Save the stage and open the feedback
* DEs "Section A: Critical" and "Section B: Hidden Section" should not be shown

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-