### PR TITLE
Fix: enable login button without edit default url

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/login/LoginViewModel.kt
+++ b/app/src/main/java/org/dhis2/usescases/login/LoginViewModel.kt
@@ -102,6 +102,10 @@ class LoginViewModel(
                                         DEFAULT_URL.ifEmpty { view.getDefaultServerProtocol() }
                                     }
 
+                                    if (DEFAULT_URL.isNotEmpty()){
+                                        onServerChanged(defaultUrl(),0,0,0)
+                                    }
+
                                     view.setUrl(defaultUrl())
                                 }
                             }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/860ryz1t0
* **Related Pull request:**

###   :gear: branches 
**app**: 
       Origin: feature/fix_enable_login_butto Target: develop-psi
**dhis2-android-SDK**: 
       Origin: develop-eyeseetea

### :tophat: What is the goal?

The app in psi should enable login button after change user and password without edit the default URL (http://data.psi.mis.org)

### :memo: How is it being implemented?

- [x] Simulate change of url to load

### :boom: How can it be tested?

The app in psi should enable login button after change user and password without edit the default URL (http://data.psi.mis.org)

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-