### PR TITLE
[Simprints] Fix hide enroll last after click on none of above

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
@@ -690,6 +690,7 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
     public void onBiometricsNoneOfTheAboveClick() {
         if(biometricsSearchStatus){
             view.hideNoneOfTheAboveButton();
+            view.hideIdentificationPlusButton();
             biometricsSearchStatus = false;
             view.activeBiometricsSearch(false);
             view.sendBiometricsNoneSelected(sessionId);


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #8694j69u2 https://app.clickup.com/t/8694j69u2
* **Related Pull request:** 


###   :gear: branches 
**app**: 
       Origin: feature/fix_hide_enroll_last_after_click_none_of_above Target: feature-simprints/bring_last_changes_2_9_1
**dhis2-android-SDK**: 
       Origin: feature-1.9.1/fix_migration_from_old_version_to_2.9.1

### :tophat: What is the goal?

Fix bug reported by the client

### :memo: How is it being implemented?

- [x] Hide enroll last after click on none of above

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-