### PR TITLE
[SPOCC] Hide programs and datasets without write data access

### DIFF
--- a/app/src/main/java/org/dhis2/data/dhislogic/DhisProgramUtils.kt
+++ b/app/src/main/java/org/dhis2/data/dhislogic/DhisProgramUtils.kt
@@ -43,6 +43,8 @@ class DhisProgramUtils @Inject constructor(val d2: D2) {
 
     fun getProgramsInCaptureOrgUnits(): Flowable<List<Program>> {
         return d2.programModule().programs()
+            // Eyeseetea customization - Only programs with write access
+            .byAccessDataWrite().isTrue
             .withTrackedEntityType()
             .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
             .get().toFlowable()

--- a/app/src/main/java/org/dhis2/usescases/main/program/ProgramRepositoryImpl.kt
+++ b/app/src/main/java/org/dhis2/usescases/main/program/ProgramRepositoryImpl.kt
@@ -62,6 +62,8 @@ internal class ProgramRepositoryImpl(
             .map { dataSetSummaries ->
                 dataSetSummaries.mapNotNull {
                     d2.dataSetModule().dataSets()
+                        // Eyeseetea customization - Only datasets with write access
+                        .byAccessDataWrite().isTrue
                         .uid(it.dataSetUid())
                         .blockingGet()?.let { dataSet ->
                             programViewModelMapper.map(


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/8694kg6au #8694kg6au
* **Related Pull request:** 

###   :gear: branches 
**app**: 
       Origin: feature-spocc/hide_programs_datasets_without_write_access Target: develop-spocc
**dhis2-android-SDK**: 
       Origin: develop-eyeseetea

### :tophat: What is the goal?

Hide read-only Program and datasets

### :memo: How is it being implemented?

- [x] Filter by write access equal to true

### :boom: How can it be tested?

The customizations in the app should work, mainly the feedback.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
![home](https://github.com/EyeSeeTea/dhis2-android-capture-app/assets/5593590/b9a9a616-0c56-4057-af3d-d20f7788d660)
