### PR TITLE
[SPOCC] Session format ui like in server year-nextYear

### DIFF
--- a/app/src/main/java/org/dhis2/data/dhislogic/DhisPeriodUtils.kt
+++ b/app/src/main/java/org/dhis2/data/dhislogic/DhisPeriodUtils.kt
@@ -72,9 +72,16 @@ class DhisPeriodUtils(
                 SimpleDateFormat(MONTHLY_FORMAT_EXPRESSION, locale).format(period.startDate()!!),
                 SimpleDateFormat(MONTHLY_FORMAT_EXPRESSION, locale).format(period.endDate()!!),
             )
-            PeriodType.Yearly ->
-                formattedDate =
+            PeriodType.Yearly -> {
+                // Eyeseetea customization - Show year-nextYear for yearly period
+    /*            formattedDate =
+                    SimpleDateFormat(YEARLY_FORMAT_EXPRESSION, locale).format(period.startDate()!!)*/
+                val formattedStartDate =
                     SimpleDateFormat(YEARLY_FORMAT_EXPRESSION, locale).format(period.startDate()!!)
+                val formattedEndDate = (formattedStartDate.toInt() + 1).toString()
+
+                formattedDate = "$formattedStartDate-$formattedEndDate"
+            }
             else ->
                 formattedDate =
                     SimpleDateFormat(SIMPLE_DATE_FORMAT, locale).format(period.startDate()!!)


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/8694kg6au #8694kg6au
* **Related Pull request:** 

###   :gear: branches 
**app**: 
       Origin: feature-spocc/season_format_like_in_server Target: feature-spocc/season_plan_upg
**dhis2-android-SDK**: 
       Origin: develop-eyeseetea

### :tophat: What is the goal?

Align the Period yearly in the manner in which period is displayed with our Seasons

### :memo: How is it being implemented?

- [x] Implement session format ui like in server year-nextYear

### :boom: How can it be tested?


### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-
![dataset-period](https://github.com/EyeSeeTea/dhis2-android-capture-app/assets/5593590/bdab6005-6080-4344-a486-f6b25d570d09)
![select-period](https://github.com/EyeSeeTea/dhis2-android-capture-app/assets/5593590/5bbcb75a-82cc-4a92-8b30-7d9e5a0c18cc)


