### PR TITLE
[SPOCC] Feature spocc/hide or validate org units

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/datasets/datasetInitial/DataSetInitialActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/datasetInitial/DataSetInitialActivity.java
@@ -127,7 +127,7 @@ public class DataSetInitialActivity extends ActivityGlobalAbstract implements Da
                     checkActionVisivbility();
                     return Unit.INSTANCE;
                 })
-                .period( dateToYearlyPeriod(selectedPeriod))
+                .withTeamValidationData(dataSetUid, dateToYearlyPeriod(selectedPeriod))
                 .build()
                 .show(getSupportFragmentManager(), OUTreeFragment.class.getSimpleName());
     }

--- a/app/src/main/java/org/dhis2/usescases/datasets/datasetInitial/DataSetInitialActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/datasetInitial/DataSetInitialActivity.java
@@ -1,5 +1,7 @@
 package org.dhis2.usescases.datasets.datasetInitial;
 
+import static org.dhis2.commons.team.DateToYearlyPeriodKt.dateToYearlyPeriod;
+
 import android.os.Bundle;
 import android.view.View;
 
@@ -110,6 +112,7 @@ public class DataSetInitialActivity extends ActivityGlobalAbstract implements Da
         if (selectedOrgUnit != null) {
             preselectedOrgUnits.add(selectedOrgUnit.uid());
         }
+
         new OUTreeFragment.Builder()
                 .showAsDialog()
                 .singleSelection()
@@ -124,6 +127,7 @@ public class DataSetInitialActivity extends ActivityGlobalAbstract implements Da
                     checkActionVisivbility();
                     return Unit.INSTANCE;
                 })
+                .period( dateToYearlyPeriod(selectedPeriod))
                 .build()
                 .show(getSupportFragmentManager(), OUTreeFragment.class.getSimpleName());
     }
@@ -149,6 +153,7 @@ public class DataSetInitialActivity extends ActivityGlobalAbstract implements Da
                     this.selectedPeriod = calendar.getTime();
                     binding.dataSetPeriodEditText.setText(periodUtils.getPeriodUIString(periodType, selectedDate, Locale.getDefault()));
                     checkCatOptionsAreValidForOrgUnit(selectedPeriod);
+                    presenter.checkOrgUnitByPeriodIsActive(selectedOrgUnit, selectedPeriod);
                     checkActionVisivbility();
                     periodDialog.dismiss();
                 })
@@ -259,12 +264,21 @@ public class DataSetInitialActivity extends ActivityGlobalAbstract implements Da
         startActivity(DataSetTableActivity.class, bundle, true, false, null);
     }
 
+    @Override
+    public void showDeactivatedTeamError() {
+        displayMessage(getString(R.string.deactivated_team_error));
+    }
+
     private void checkActionVisivbility() {
         boolean visible = true;
         if (selectedOrgUnit == null)
             visible = false;
         if (selectedPeriod == null)
             visible = false;
+
+        if (!presenter.isOrgUnitByPeriodIsActive(selectedOrgUnit, selectedPeriod))
+            visible = false;
+
         for (String key : selectedCatOptions.keySet()) {
             if (selectedCatOptions.get(key) == null)
                 visible = false;

--- a/app/src/main/java/org/dhis2/usescases/datasets/datasetInitial/DataSetInitialContract.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/datasetInitial/DataSetInitialContract.java
@@ -41,6 +41,8 @@ public class DataSetInitialContract {
         void setOrgUnit(OrganisationUnit organisationUnit);
 
         void navigateToDataSetTable(String catOptionCombo, String periodId);
+
+        void showDeactivatedTeamError();
     }
 
     public interface Presenter extends AbstractActivityContracts.Presenter {
@@ -57,6 +59,10 @@ public class DataSetInitialContract {
         void onActionButtonClick(PeriodType periodType);
 
         CategoryOption getCatOption(String selectedOption);
+
+        void checkOrgUnitByPeriodIsActive(OrganisationUnit selectedOrgUnit, Date selectedPeriod);
+
+        boolean isOrgUnitByPeriodIsActive(OrganisationUnit selectedOrgUnit, Date selectedPeriod);
     }
 
 

--- a/app/src/main/java/org/dhis2/usescases/datasets/datasetInitial/DataSetInitialModel.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/datasetInitial/DataSetInitialModel.java
@@ -13,6 +13,8 @@ import java.util.List;
 
 @AutoValue
 public abstract class DataSetInitialModel {
+    @NonNull
+    public abstract String uid();
 
     @NonNull
     public abstract String displayName();
@@ -36,14 +38,15 @@ public abstract class DataSetInitialModel {
     public abstract Integer openFuturePeriods();
 
     @NonNull
-    public static DataSetInitialModel create(@NonNull String displayName,
+    public static DataSetInitialModel create(@NonNull String uid,
+                                             @NonNull String displayName,
                                              @Nullable String description,
                                              @NonNull String categoryCombo,
                                              @NonNull String categoryComboName,
                                              @NonNull PeriodType periodType,
                                              @NonNull List<Category> categories,
                                              @Nullable Integer openFuturePeriods) {
-        return new AutoValue_DataSetInitialModel(displayName, description, categoryCombo, categoryComboName, periodType, categories, openFuturePeriods);
+        return new AutoValue_DataSetInitialModel(uid, displayName, description, categoryCombo, categoryComboName, periodType, categories, openFuturePeriods);
     }
 
     public final List<Category> getCategories() {

--- a/app/src/main/java/org/dhis2/usescases/datasets/datasetInitial/DataSetInitialModule.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/datasetInitial/DataSetInitialModule.java
@@ -28,8 +28,8 @@ public class DataSetInitialModule {
 
     @Provides
     @PerActivity
-    DataSetInitialContract.Presenter providesPresenter(DataSetInitialRepository dataSetInitialRepository, SchedulerProvider schedulerProvider) {
-        return new DataSetInitialPresenter(view, dataSetInitialRepository, schedulerProvider);
+    DataSetInitialContract.Presenter providesPresenter(D2 d2, DataSetInitialRepository dataSetInitialRepository, SchedulerProvider schedulerProvider) {
+        return new DataSetInitialPresenter(view, d2, dataSetInitialRepository, schedulerProvider);
     }
 
     @Provides

--- a/app/src/main/java/org/dhis2/usescases/datasets/datasetInitial/DataSetInitialPresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/datasetInitial/DataSetInitialPresenter.kt
@@ -5,16 +5,21 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.functions.BiFunction
 import org.dhis2.commons.data.tuples.Pair
 import org.dhis2.commons.schedulers.SchedulerProvider
+import org.dhis2.commons.team.dateToYearlyPeriod
+import org.dhis2.commons.team.isActiveOrgUnit
 import org.dhis2.data.dhislogic.inDateRange
 import org.dhis2.data.dhislogic.inOrgUnit
+import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.category.CategoryOption
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
 import org.hisp.dhis.android.core.period.PeriodType
 import timber.log.Timber
-import java.util.ArrayList
+import java.util.Date
+
 
 class DataSetInitialPresenter(
     private val view: DataSetInitialContract.View,
+    private val d2: D2,
     private val dataSetInitialRepository: DataSetInitialRepository,
     private val schedulerProvider: SchedulerProvider,
 ) : DataSetInitialContract.Presenter {
@@ -131,6 +136,35 @@ class DataSetInitialPresenter(
 
     override fun getCatOption(selectedOption: String): CategoryOption {
         return dataSetInitialRepository.getCategoryOption(selectedOption)
+    }
+
+    override fun checkOrgUnitByPeriodIsActive(
+        selectedOrgUnit: OrganisationUnit?,
+        selectedPeriod: Date
+    ) {
+        // Eyeseetea customization
+
+        if (!isOrgUnitByPeriodIsActive(selectedOrgUnit, selectedPeriod)) {
+            view.showDeactivatedTeamError()
+        }
+    }
+
+    override fun isOrgUnitByPeriodIsActive(
+        selectedOrgUnit: OrganisationUnit?,
+        selectedPeriod: Date?
+    ):Boolean {
+        // Eyeseetea customization
+        //enrollInOrgUnit(selectedOrgUnit.uid(), programUid, uid, selectedEnrollmentDate, queryData);
+        val period = dateToYearlyPeriod(selectedPeriod)
+
+        if (period != null && selectedOrgUnit != null) {
+            val isActivatedOrgUnit: Boolean = isActiveOrgUnit(d2, selectedOrgUnit.uid(), period)
+            if (!isActivatedOrgUnit) {
+                return false
+            }
+        }
+
+        return true
     }
 
     override fun onDettach() {

--- a/app/src/main/java/org/dhis2/usescases/datasets/datasetInitial/DataSetInitialPresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/datasetInitial/DataSetInitialPresenter.kt
@@ -158,7 +158,9 @@ class DataSetInitialPresenter(
         val period = dateToYearlyPeriod(selectedPeriod)
 
         if (period != null && selectedOrgUnit != null) {
-            val isActivatedOrgUnit: Boolean = isActiveOrgUnit(d2, selectedOrgUnit.uid(), period)
+            val dataSetUid = dataSetInitialRepository.dataSet().blockingFirst().uid()
+
+            val isActivatedOrgUnit: Boolean = isActiveOrgUnit(d2, dataSetUid, selectedOrgUnit.uid(), period)
             if (!isActivatedOrgUnit) {
                 return false
             }

--- a/app/src/main/java/org/dhis2/usescases/datasets/datasetInitial/DataSetInitialRepositoryImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/datasetInitial/DataSetInitialRepositoryImpl.java
@@ -56,6 +56,7 @@ public class DataSetInitialRepositoryImpl implements DataSetInitialRepository {
                             .blockingGet();
 
                     return DataSetInitialModel.create(
+                            dataSetUid,
                             dataSet.displayName(),
                             dataSet.description(),
                             dataSet.categoryCombo().uid(),

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/data/EventDetailsRepository.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/data/EventDetailsRepository.kt
@@ -1,6 +1,7 @@
 package org.dhis2.usescases.eventsWithoutRegistration.eventDetails.data
 
 import io.reactivex.Observable
+import org.dhis2.commons.team.isActiveOrgUnit
 import org.dhis2.data.dhislogic.AUTH_ALL
 import org.dhis2.data.dhislogic.AUTH_UNCOMPLETE_EVENT
 import org.dhis2.form.model.FieldUiModel
@@ -325,5 +326,9 @@ class EventDetailsRepository(
                 d2Error,
             ),
         )
+    }
+
+    fun isOrgUnitActive(selectedOrgUnit: String, dateToYearlyPeriod: String): Boolean {
+        return isActiveOrgUnit(d2, selectedOrgUnit, dateToYearlyPeriod)
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/data/EventDetailsRepository.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/data/EventDetailsRepository.kt
@@ -329,6 +329,6 @@ class EventDetailsRepository(
     }
 
     fun isOrgUnitActive(selectedOrgUnit: String, dateToYearlyPeriod: String): Boolean {
-        return isActiveOrgUnit(d2, selectedOrgUnit, dateToYearlyPeriod)
+        return isActiveOrgUnit(d2, programUid, selectedOrgUnit, dateToYearlyPeriod)
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/domain/ConfigureEventDetails.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/domain/ConfigureEventDetails.kt
@@ -41,9 +41,11 @@ class ConfigureEventDetails(
         val programStage = repository.getProgramStage()
 
         val isOrgUnitActive = if (selectedDate == null || selectedOrgUnit == null) true
-        else repository.isOrgUnitActive(
-            selectedOrgUnit, dateToYearlyPeriod(selectedDate)
-        )
+        else dateToYearlyPeriod(selectedDate)?.let {
+            repository.isOrgUnitActive(
+                selectedOrgUnit, it
+            )
+        }?: true
 
         return flowOf(
             EventDetails(
@@ -63,7 +65,7 @@ class ConfigureEventDetails(
                 actionButtonText = getActionButtonText(),
                 canReopen = repository.getCanReopen(),
                 //Eyeseetea customization
-                isOrgUnitActive = isOrgUnitActive
+                isOrgUnitActive = isOrgUnitActive ,
             ),
         )
     }

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/domain/ConfigureEventDetails.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/domain/ConfigureEventDetails.kt
@@ -66,6 +66,7 @@ class ConfigureEventDetails(
                 canReopen = repository.getCanReopen(),
                 //Eyeseetea customization
                 isOrgUnitActive = isOrgUnitActive ,
+                program = repository.getProgram()?.uid() ?: "",
             ),
         )
     }

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/models/EventDetails.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/models/EventDetails.kt
@@ -19,4 +19,5 @@ data class EventDetails(
     val isActionButtonVisible: Boolean = false,
     val actionButtonText: String? = null,
     val canReopen: Boolean = false,
+    val isOrgUnitActive: Boolean = true ,
 )

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/models/EventDetails.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/models/EventDetails.kt
@@ -20,4 +20,5 @@ data class EventDetails(
     val actionButtonText: String? = null,
     val canReopen: Boolean = false,
     val isOrgUnitActive: Boolean = true ,
+    val program: String? = null,
 )

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/ui/EventDetailsFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/ui/EventDetailsFragment.kt
@@ -296,7 +296,10 @@ class EventDetailsFragment : FragmentGlobalAbstract() {
                     )
                 }
             } else if (!catCombo.isDefault) {
-                ProvideEmptyCategorySelector(name = catCombo.displayName ?: getString(R.string.cat_combo), option = getString(R.string.no_options))
+                ProvideEmptyCategorySelector(
+                    name = catCombo.displayName ?: getString(R.string.cat_combo),
+                    option = getString(R.string.no_options)
+                )
             }
             ProvideCoordinates(
                 coordinates = coordinates,
@@ -363,8 +366,11 @@ class EventDetailsFragment : FragmentGlobalAbstract() {
             .onSelection { selectedOrgUnits ->
                 viewModel.setUpOrgUnit(selectedOrgUnit = selectedOrgUnits.firstOrNull()?.uid())
             }
-            //eyeseetea customization- filter by active team
-            .period(dateToYearlyPeriod(viewModel.eventDate.value.currentDate))
+            //Eyeseetea customization- filter by active team
+            .withTeamValidationData(
+                viewModel.eventDetails.value.program!!,
+                dateToYearlyPeriod(viewModel.eventDate.value.currentDate)
+            )
             .build()
             .show(childFragmentManager, "ORG_UNIT_DIALOG")
     }

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/ui/EventDetailsFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/ui/EventDetailsFragment.kt
@@ -32,6 +32,7 @@ import org.dhis2.commons.locationprovider.LocationSettingLauncher
 import org.dhis2.commons.orgunitselector.OUTreeFragment
 import org.dhis2.commons.orgunitselector.OrgUnitSelectorScope
 import org.dhis2.commons.resources.ResourceManager
+import org.dhis2.commons.team.dateToYearlyPeriod
 import org.dhis2.databinding.EventDetailsFragmentBinding
 import org.dhis2.maps.views.MapSelectorActivity
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.injection.EventDetailsComponentProvider
@@ -228,6 +229,10 @@ class EventDetailsFragment : FragmentGlobalAbstract() {
             displayMessage(message)
             onEventReopened?.invoke()
         }
+
+        viewModel.showDeactivatedTeamError = {
+            displayMessage(getString(R.string.deactivated_team_error))
+        }
     }
 
     @Composable
@@ -344,6 +349,11 @@ class EventDetailsFragment : FragmentGlobalAbstract() {
     }
 
     private fun showOrgUnitDialog() {
+        //Eyeseetea customization- filter by active team
+        val period = viewModel.eventDate.value.currentDate?.let {
+            dateToYearlyPeriod(it)
+        }
+
         OUTreeFragment.Builder()
             .showAsDialog()
             .withPreselectedOrgUnits(
@@ -358,6 +368,8 @@ class EventDetailsFragment : FragmentGlobalAbstract() {
             .onSelection { selectedOrgUnits ->
                 viewModel.setUpOrgUnit(selectedOrgUnit = selectedOrgUnits.firstOrNull()?.uid())
             }
+            //eyeseetea customization- filter by active team
+            .period(period)
             .build()
             .show(childFragmentManager, "ORG_UNIT_DIALOG")
     }

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/ui/EventDetailsFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/ui/EventDetailsFragment.kt
@@ -349,11 +349,6 @@ class EventDetailsFragment : FragmentGlobalAbstract() {
     }
 
     private fun showOrgUnitDialog() {
-        //Eyeseetea customization- filter by active team
-        val period = viewModel.eventDate.value.currentDate?.let {
-            dateToYearlyPeriod(it)
-        }
-
         OUTreeFragment.Builder()
             .showAsDialog()
             .withPreselectedOrgUnits(
@@ -369,7 +364,7 @@ class EventDetailsFragment : FragmentGlobalAbstract() {
                 viewModel.setUpOrgUnit(selectedOrgUnit = selectedOrgUnits.firstOrNull()?.uid())
             }
             //eyeseetea customization- filter by active team
-            .period(period)
+            .period(dateToYearlyPeriod(viewModel.eventDate.value.currentDate))
             .build()
             .show(childFragmentManager, "ORG_UNIT_DIALOG")
     }

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/ui/EventDetailsViewModel.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/ui/EventDetailsViewModel.kt
@@ -58,6 +58,7 @@ class EventDetailsViewModel(
     var showEventUpdateStatus: ((result: String) -> Unit)? = null
     var onReopenError: ((message: String) -> Unit)? = null
     var onReopenSuccess: ((message: String) -> Unit)? = null
+    var showDeactivatedTeamError: (() -> Unit)? = null
 
     private val _eventDetails: MutableStateFlow<EventDetails> = MutableStateFlow(EventDetails())
     val eventDetails: StateFlow<EventDetails> get() = _eventDetails
@@ -148,6 +149,12 @@ class EventDetailsViewModel(
                 .flowOn(Dispatchers.IO)
                 .collect {
                     _eventDetails.value = it
+
+                    //Eyeseetea customization
+                    if (!it.isOrgUnitActive){
+                        showDeactivatedTeamError?.invoke()
+                    }
+
                     EventDetailIdlingResourceSingleton.decrement()
                 }
         }

--- a/app/src/main/java/org/dhis2/usescases/main/program/ProgramRepositoryImpl.kt
+++ b/app/src/main/java/org/dhis2/usescases/main/program/ProgramRepositoryImpl.kt
@@ -31,11 +31,13 @@ internal class ProgramRepositoryImpl(
     private var baseProgramCache: List<ProgramViewModel> = emptyList()
 
     override fun homeItems(syncStatusData: SyncStatusData): Flowable<List<ProgramViewModel>> {
-        return programModels(syncStatusData).onErrorReturn { arrayListOf() }
+        val items = programModels(syncStatusData).onErrorReturn { arrayListOf() }
             .mergeWith(aggregatesModels(syncStatusData).onErrorReturn { arrayListOf() })
             .flatMapIterable { data -> data }
             .sorted { p1, p2 -> p1.title.compareTo(p2.title, ignoreCase = true) }
-            .toList().toFlowable()
+            .toList()
+
+        return items.toFlowable()
             .subscribeOn(schedulerProvider.io())
             .onErrorReturn { arrayListOf() }
             .doOnNext {
@@ -162,6 +164,7 @@ internal class ProgramRepositoryImpl(
                             D2ProgressSyncStatus.ERROR,
                             D2ProgressSyncStatus.PARTIAL_ERROR,
                             -> ProgramDownloadState.ERROR
+
                             null -> ProgramDownloadState.DOWNLOADED
                         }
 

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.java
@@ -592,6 +592,11 @@ public class SearchTEActivity extends ActivityGlobalAbstract implements SearchTE
                 }).show("TEI_SYNC");
     }
 
+    @Override
+    public void showDeactivatedTeamError() {
+        displayMessage(getString(R.string.deactivated_team_error));
+    }
+
     private void setInitialProgram(List<ProgramSpinnerModel> programs) {
         for (int i = 0; i < programs.size(); i++) {
             if (programs.get(i).getUid().equals(initialProgram)) {

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEContractsModule.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEContractsModule.java
@@ -66,6 +66,8 @@ public class SearchTEContractsModule {
         void hideFilter();
 
         void showSyncDialog(String teiUid);
+
+        void showDeactivatedTeamError();
     }
 
     public interface Presenter {

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
@@ -10,7 +10,6 @@ import static org.dhis2.commons.matomo.Labels.CLICK;
 import static org.dhis2.commons.team.DateToYearlyPeriodKt.dateToYearlyPeriod;
 import static org.dhis2.commons.team.IsActiveOrgUnitKt.isActiveOrgUnit;
 import static org.dhis2.usescases.teiDashboard.dashboardfragments.relationships.RelationshipFragment.TEI_A_UID;
-import static org.dhis2.utils.DateUtils.YEARLY_FORMAT_EXPRESSION;
 import static org.dhis2.utils.analytics.AnalyticsConstants.ADD_RELATIONSHIP;
 import static org.dhis2.utils.analytics.AnalyticsConstants.CREATE_ENROLL;
 import static org.dhis2.utils.analytics.AnalyticsConstants.DELETE_RELATIONSHIP;
@@ -366,7 +365,8 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
                 // Eyeseetea customization
                 //enrollInOrgUnit(selectedOrgUnit.uid(), programUid, uid, selectedEnrollmentDate, queryData);
                 String period = dateToYearlyPeriod(selectedEnrollmentDate);
-                boolean isActivatedOrgUnit = isActiveOrgUnit(d2, selectedOrgUnit.uid(), period);
+
+                boolean isActivatedOrgUnit = isActiveOrgUnit(d2, currentProgram.getValue(), selectedOrgUnit.uid(), period);
 
                 if (isActivatedOrgUnit) {
                     enrollInOrgUnit(selectedOrgUnit.uid(), programUid, uid, selectedEnrollmentDate, queryData);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -981,4 +981,5 @@
     <string name="change_server_url_warning">Please confirm that metadata in the new server is equal to this one. Sync errors could occur in case server is not totally synced with current one. Are you sure?</string>
     <string name="select_upg">Select UPG</string>
     <string name="empty_upg_items">There are no UPG items</string>
+    <string name="deactivated_team_error">This team is not active for the selected period</string>
 </resources>

--- a/commons/src/main/java/org/dhis2/commons/orgunitselector/OURepositoryConfiguration.kt
+++ b/commons/src/main/java/org/dhis2/commons/orgunitselector/OURepositoryConfiguration.kt
@@ -1,5 +1,6 @@
 package org.dhis2.commons.orgunitselector
 
+import org.dhis2.commons.team.nonActiveOrgUnits
 import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
@@ -8,6 +9,7 @@ import org.hisp.dhis.android.core.organisationunit.OrganisationUnitCollectionRep
 class OURepositoryConfiguration(
     private val d2: D2,
     private val orgUnitSelectorScope: OrgUnitSelectorScope,
+    private val period: String? = null,
 ) {
     fun orgUnitRepository(name: String?): List<OrganisationUnit> {
         var orgUnitRepository = d2.organisationUnitModule().organisationUnits()
@@ -24,6 +26,7 @@ class OURepositoryConfiguration(
             is OrgUnitSelectorScope.UserCaptureScope,
             ->
                 applyCaptureFilter(orgUnitRepository)
+
             is OrgUnitSelectorScope.ProgramSearchScope,
             is OrgUnitSelectorScope.DataSetSearchScope,
             is OrgUnitSelectorScope.UserSearchScope,
@@ -36,16 +39,26 @@ class OURepositoryConfiguration(
             is OrgUnitSelectorScope.DataSetSearchScope,
             ->
                 orgUnitRepository.byDataSetUids(listOf(orgUnitSelectorScope.uid!!))
+
             is OrgUnitSelectorScope.ProgramCaptureScope,
             is OrgUnitSelectorScope.ProgramSearchScope,
             ->
                 orgUnitRepository.byProgramUids(listOf(orgUnitSelectorScope.uid!!))
+
             is OrgUnitSelectorScope.UserCaptureScope,
             is OrgUnitSelectorScope.UserSearchScope,
             ->
                 orgUnitRepository
         }
-        return orgUnitRepository.blockingGet()
+
+        //Eyeseetea customization - filter by active team
+        //return orgUnitRepository.blockingGet()
+
+        val nonActiveOrgUnits = if (period == null) listOf() else nonActiveOrgUnits(d2, period)
+
+        return orgUnitRepository.blockingGet().filter {
+            nonActiveOrgUnits.contains(it.uid()).not()
+        }
     }
 
     fun countChildren(parentOrgUnitUid: String, selectedOrgUnits: List<String>): Int {

--- a/commons/src/main/java/org/dhis2/commons/orgunitselector/OURepositoryConfiguration.kt
+++ b/commons/src/main/java/org/dhis2/commons/orgunitselector/OURepositoryConfiguration.kt
@@ -1,5 +1,6 @@
 package org.dhis2.commons.orgunitselector
 
+import org.dhis2.commons.team.ValidationData
 import org.dhis2.commons.team.nonActiveOrgUnits
 import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
@@ -9,7 +10,7 @@ import org.hisp.dhis.android.core.organisationunit.OrganisationUnitCollectionRep
 class OURepositoryConfiguration(
     private val d2: D2,
     private val orgUnitSelectorScope: OrgUnitSelectorScope,
-    private val period: String? = null,
+    private val validationData: ValidationData?,
 ) {
     fun orgUnitRepository(name: String?): List<OrganisationUnit> {
         var orgUnitRepository = d2.organisationUnitModule().organisationUnits()
@@ -54,7 +55,7 @@ class OURepositoryConfiguration(
         //Eyeseetea customization - filter by active team
         //return orgUnitRepository.blockingGet()
 
-        val nonActiveOrgUnits = if (period == null) listOf() else nonActiveOrgUnits(d2, period)
+        val nonActiveOrgUnits = if (validationData == null) listOf() else nonActiveOrgUnits(d2, validationData)
 
         return orgUnitRepository.blockingGet().filter {
             nonActiveOrgUnits.contains(it.uid()).not()

--- a/commons/src/main/java/org/dhis2/commons/orgunitselector/OUTreeFragment.kt
+++ b/commons/src/main/java/org/dhis2/commons/orgunitselector/OUTreeFragment.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import com.google.accompanist.themeadapter.material3.Mdc3Theme
+import org.dhis2.commons.team.ValidationData
 import org.dhis2.ui.dialogs.orgunit.OrgUnitSelectorActions
 import org.dhis2.ui.dialogs.orgunit.OrgUnitSelectorDialog
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
@@ -27,6 +28,7 @@ const val ARG_SINGLE_SELECTION = "OUTreeFragment.ARG_SINGLE_SELECTION"
 const val ARG_SCOPE = "OUTreeFragment.ARG_SCOPE"
 const val ARG_PRE_SELECTED_OU = "OUTreeFragment.ARG_PRE_SELECTED_OU"
 const val PERIOD = "OUTreeFragment.PERIOD"
+const val PROGRAM_OR_DATASET_TO_VALIDATE = "OUTreeFragment.PROGRAM_OR_DATASET_TO_VALIDATE"
 
 class OUTreeFragment private constructor() : DialogFragment() {
 
@@ -37,6 +39,7 @@ class OUTreeFragment private constructor() : DialogFragment() {
         private var selectionListener: ((selectedOrgUnits: List<OrganisationUnit>) -> Unit) = {}
         private var orgUnitScope: OrgUnitSelectorScope = OrgUnitSelectorScope.UserSearchScope()
         private var period: String? = null
+        private var programOrDataSetToValidate: String? = null
         fun showAsDialog() = apply {
             showAsDialog = true
         }
@@ -68,8 +71,9 @@ class OUTreeFragment private constructor() : DialogFragment() {
                 this.selectionListener = selectionListener
             }
 
-        fun period(period: String?) = apply {
+        fun withTeamValidationData(programOrDataSetToValidate:String, period: String?) = apply {
             this.period = period
+            this.programOrDataSetToValidate = programOrDataSetToValidate
         }
 
         fun build(): OUTreeFragment {
@@ -81,6 +85,7 @@ class OUTreeFragment private constructor() : DialogFragment() {
                     putParcelable(ARG_SCOPE, orgUnitScope)
                     putStringArrayList(ARG_PRE_SELECTED_OU, ArrayList(preselectedOrgUnits))
                     putString(PERIOD, period)
+                    putString(PROGRAM_OR_DATASET_TO_VALIDATE, programOrDataSetToValidate)
                 }
             }
         }
@@ -95,6 +100,8 @@ class OUTreeFragment private constructor() : DialogFragment() {
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
+
+        val programOrDataSetToValidate = requireArguments().getString(PROGRAM_OR_DATASET_TO_VALIDATE)
 
         (context.applicationContext as OUTreeComponentProvider).provideOUTreeComponent(
             OUTreeModule(
@@ -111,7 +118,9 @@ class OUTreeFragment private constructor() : DialogFragment() {
                         ARG_SCOPE,
                     )!!
                 },
-                period = requireArguments().getString(PERIOD),
+                validationData = if (programOrDataSetToValidate == null) null else ValidationData(
+                    programOrDataSetUid = programOrDataSetToValidate,
+                    period = requireArguments().getString(PERIOD))
             ),
         )?.inject(this)
     }

--- a/commons/src/main/java/org/dhis2/commons/orgunitselector/OUTreeFragment.kt
+++ b/commons/src/main/java/org/dhis2/commons/orgunitselector/OUTreeFragment.kt
@@ -26,6 +26,7 @@ const val ARG_SHOW_AS_DIALOG = "OUTreeFragment.ARG_SHOW_AS_DIALOG"
 const val ARG_SINGLE_SELECTION = "OUTreeFragment.ARG_SINGLE_SELECTION"
 const val ARG_SCOPE = "OUTreeFragment.ARG_SCOPE"
 const val ARG_PRE_SELECTED_OU = "OUTreeFragment.ARG_PRE_SELECTED_OU"
+const val PERIOD = "OUTreeFragment.PERIOD"
 
 class OUTreeFragment private constructor() : DialogFragment() {
 
@@ -35,6 +36,7 @@ class OUTreeFragment private constructor() : DialogFragment() {
         private var singleSelection = false
         private var selectionListener: ((selectedOrgUnits: List<OrganisationUnit>) -> Unit) = {}
         private var orgUnitScope: OrgUnitSelectorScope = OrgUnitSelectorScope.UserSearchScope()
+        private var period: String? = null
         fun showAsDialog() = apply {
             showAsDialog = true
         }
@@ -66,6 +68,10 @@ class OUTreeFragment private constructor() : DialogFragment() {
                 this.selectionListener = selectionListener
             }
 
+        fun period(period: String?) = apply {
+            this.period = period
+        }
+
         fun build(): OUTreeFragment {
             return OUTreeFragment().apply {
                 selectionCallback = selectionListener
@@ -74,6 +80,7 @@ class OUTreeFragment private constructor() : DialogFragment() {
                     putBoolean(ARG_SINGLE_SELECTION, singleSelection)
                     putParcelable(ARG_SCOPE, orgUnitScope)
                     putStringArrayList(ARG_PRE_SELECTED_OU, ArrayList(preselectedOrgUnits))
+                    putString(PERIOD, period)
                 }
             }
         }
@@ -104,6 +111,7 @@ class OUTreeFragment private constructor() : DialogFragment() {
                         ARG_SCOPE,
                     )!!
                 },
+                period = requireArguments().getString(PERIOD),
             ),
         )?.inject(this)
     }

--- a/commons/src/main/java/org/dhis2/commons/orgunitselector/OUTreeModule.kt
+++ b/commons/src/main/java/org/dhis2/commons/orgunitselector/OUTreeModule.kt
@@ -37,6 +37,7 @@ class OUTreeModule(
     private val preselectedOrgUnits: List<String>,
     private val singleSelection: Boolean,
     private val orgUnitSelectorScope: OrgUnitSelectorScope,
+    private val period:String? = null,
 ) {
 
     @Provides
@@ -54,6 +55,6 @@ class OUTreeModule(
 
     @Provides
     internal fun providesOUTreeRepository(d2: D2): OUTreeRepository {
-        return OUTreeRepository(OURepositoryConfiguration(d2, orgUnitSelectorScope))
+        return OUTreeRepository(OURepositoryConfiguration(d2, orgUnitSelectorScope,period))
     }
 }

--- a/commons/src/main/java/org/dhis2/commons/orgunitselector/OUTreeModule.kt
+++ b/commons/src/main/java/org/dhis2/commons/orgunitselector/OUTreeModule.kt
@@ -29,6 +29,7 @@ package org.dhis2.commons.orgunitselector
 
 import dagger.Module
 import dagger.Provides
+import org.dhis2.commons.team.ValidationData
 import org.dhis2.commons.viewmodel.DispatcherProvider
 import org.hisp.dhis.android.core.D2
 
@@ -37,7 +38,7 @@ class OUTreeModule(
     private val preselectedOrgUnits: List<String>,
     private val singleSelection: Boolean,
     private val orgUnitSelectorScope: OrgUnitSelectorScope,
-    private val period:String? = null,
+    private val validationData: ValidationData?,
 ) {
 
     @Provides
@@ -55,6 +56,6 @@ class OUTreeModule(
 
     @Provides
     internal fun providesOUTreeRepository(d2: D2): OUTreeRepository {
-        return OUTreeRepository(OURepositoryConfiguration(d2, orgUnitSelectorScope,period))
+        return OUTreeRepository(OURepositoryConfiguration(d2, orgUnitSelectorScope, validationData))
     }
 }

--- a/commons/src/main/java/org/dhis2/commons/team/dateToYearlyPeriod.kt
+++ b/commons/src/main/java/org/dhis2/commons/team/dateToYearlyPeriod.kt
@@ -5,7 +5,9 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-fun dateToYearlyPeriod(date: Date): String {
+fun dateToYearlyPeriod(date: Date?): String? {
+    if (date ==null) return null
+
     return SimpleDateFormat(
         YEARLY_FORMAT_EXPRESSION,
         Locale.getDefault()

--- a/commons/src/main/java/org/dhis2/commons/team/dateToYearlyPeriod.kt
+++ b/commons/src/main/java/org/dhis2/commons/team/dateToYearlyPeriod.kt
@@ -1,0 +1,13 @@
+package org.dhis2.commons.team
+
+import org.dhis2.commons.date.DateUtils.YEARLY_FORMAT_EXPRESSION
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+fun dateToYearlyPeriod(date: Date): String {
+    return SimpleDateFormat(
+        YEARLY_FORMAT_EXPRESSION,
+        Locale.getDefault()
+    ).format(date)
+}

--- a/commons/src/main/java/org/dhis2/commons/team/isActiveOrgUnit.kt
+++ b/commons/src/main/java/org/dhis2/commons/team/isActiveOrgUnit.kt
@@ -4,7 +4,29 @@ import org.hisp.dhis.android.core.D2
 
 private const val teamProfileDataset = "lXtB2FRocsa"
 private const val statusDataElement = "I1CBbsdTg3A"
-fun isActiveOrgUnit(d2: D2, orgUnitId: String, period: String): Boolean {
+
+val programsOrDataSetsToValidate = listOf(
+    "JsM6wTUTsL6", // End of season report
+    "sPRFZ9fP9w3", // Ministry alignment
+    "KvYM1NhKCD6", // ministry training
+    "rGXtRfPdES9", // monthly reconciliation
+    "v0YLrAILuce", // outreach event
+    "BVHxsLhrCde", // resource tracking
+    "WCJhvPcJomX", // season plan
+    "wGzMn208Oh9", // tgj observation form
+    "ywS5wi0Y5em"  // vision meeting
+)
+
+fun isActiveOrgUnit(
+    d2: D2,
+    programOrDataSetUid: String,
+    orgUnitId: String,
+    period: String
+): Boolean {
+    if (!programsOrDataSetsToValidate.contains(programOrDataSetUid)) {
+        return true
+    }
+
     val dataValues = d2.dataValueModule().dataValues()
         .byDataSetUid(teamProfileDataset)
         .byOrganisationUnitUid().eq(orgUnitId)
@@ -19,10 +41,20 @@ fun isActiveOrgUnit(d2: D2, orgUnitId: String, period: String): Boolean {
     }
 }
 
-fun nonActiveOrgUnits(d2: D2, period: String): List<String> {
+data class ValidationData(
+    val programOrDataSetUid: String,
+    val period: String?,
+)
+
+fun nonActiveOrgUnits(d2: D2, validationData: ValidationData): List<String> {
+    if (!programsOrDataSetsToValidate.contains(validationData.programOrDataSetUid) ||
+        validationData.period == null) {
+        return listOf()
+    }
+
     val dataValues = d2.dataValueModule().dataValues()
         .byDataSetUid(teamProfileDataset)
-        .byPeriod().eq(period)
+        .byPeriod().eq(validationData.period)
         .blockingGet()
 
     val statusDataValues = dataValues.filter {

--- a/commons/src/main/java/org/dhis2/commons/team/isActiveOrgUnit.kt
+++ b/commons/src/main/java/org/dhis2/commons/team/isActiveOrgUnit.kt
@@ -1,0 +1,34 @@
+package org.dhis2.commons.team
+
+import org.hisp.dhis.android.core.D2
+
+private const val teamProfileDataset = "lXtB2FRocsa"
+private const val statusDataElement = "I1CBbsdTg3A"
+fun isActiveOrgUnit(d2: D2, orgUnitId: String, period: String): Boolean {
+    val dataValues = d2.dataValueModule().dataValues()
+        .byDataSetUid(teamProfileDataset)
+        .byOrganisationUnitUid().eq(orgUnitId)
+        .byPeriod().eq(period).blockingGet()
+
+    val statusDataValue = dataValues.find { it.dataElement() == statusDataElement }
+
+    return if (statusDataValue?.value() != null) {
+        statusDataValue.value()!!.lowercase() == "active"
+    } else {
+        true
+    }
+}
+
+fun nonActiveOrgUnits(d2: D2, period: String): List<String> {
+    val dataValues = d2.dataValueModule().dataValues()
+        .byDataSetUid(teamProfileDataset)
+        .byPeriod().eq(period)
+        .blockingGet()
+
+    val statusDataValues = dataValues.filter {
+        it.dataElement() == statusDataElement && (it.value() ?: "").lowercase() != "active"
+    }
+
+    return statusDataValues.map { it.organisationUnit() ?: "" }.filter { it != "" }
+
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/8694kg6au #8694kg6au
* **Related Pull request:** 

###   :gear: branches 
**app**: 
       Origin: feature-spocc/season_format_like_in_server Target: feature-spocc/season_plan_upg
**dhis2-android-SDK**: 
       Origin: develop-eyeseetea

### :tophat: What is the goal?

Align the Period yearly in the manner in which period is displayed with our Seasons

### :memo: How is it being implemented?

- [x] Validate org unit for tracker programs
- [x] Hide and Validate org unit for event programs
- [x] Hide and Validate org unit for data sets
- [x] Only validate for hardcoded programs or data sets

### :boom: How can it be tested?

The user should not be able to create entries (TEI event, event, data values) for non-active org units for a specific programs and datasets

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-



