### PR TITLE
[SPIP] Hide schedule event in timeline mode

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/domain/GetNewEventCreationTypeOptions.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/domain/GetNewEventCreationTypeOptions.kt
@@ -40,9 +40,13 @@ class GetNewEventCreationTypeOptions(
     }
 
     private fun shouldShowReferralEvents(programUid: String): Boolean {
-        return false
+        programConfigurationRepository.getConfigurationByProgram(programUid)
+            ?.let { programConfiguration ->
+                return programConfiguration.disableReferrals() != true
+            }
+        return true
     }
 
     private fun shouldShowScheduleEvents(programStage: ProgramStage) =
-        false
+        programStage.hideDueDate() != true
 }

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/domain/GetNewEventCreationTypeOptions.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/domain/GetNewEventCreationTypeOptions.kt
@@ -17,11 +17,19 @@ class GetNewEventCreationTypeOptions(
     ): List<EventCreationType> {
         val options: MutableList<EventCreationType> = mutableListOf()
 
+        // EyeSeeTea customization - Not show schedule events when programStage is null
+        // (timeline events view)
+    /*    programStage?.let {
+            if (shouldShowScheduleEvents(it)) {
+                options.add(SCHEDULE)
+            }
+        } ?: options.add(SCHEDULE)*/
+
         programStage?.let {
             if (shouldShowScheduleEvents(it)) {
                 options.add(SCHEDULE)
             }
-        } ?: options.add(SCHEDULE)
+        }
 
         options.add(ADDNEW)
 
@@ -32,13 +40,9 @@ class GetNewEventCreationTypeOptions(
     }
 
     private fun shouldShowReferralEvents(programUid: String): Boolean {
-        programConfigurationRepository.getConfigurationByProgram(programUid)
-            ?.let { programConfiguration ->
-                return programConfiguration.disableReferrals() != true
-            }
-        return true
+        return false
     }
 
     private fun shouldShowScheduleEvents(programStage: ProgramStage) =
-        programStage.hideDueDate() != true
+        false
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/8695fm2yx #8695fm2yx
* **Related Pull request:** https://github.com/EyeSeeTea/dhis2-android-sdk/pull/450


###   :gear: branches 
**app**: 
       Origin: ffeature-spip/hide_schedule_event_in_timeline_mode Target: develop-spip
**dhis2-android-SDK**: 
       Origin: develop-eyeseetea

### :tophat: What is the goal?

Only visible add new in time line mode

### :memo: How is it being implemented?

- [x] Hardcode  to hide schedule in timeline mode

### :boom: How can it be tested?

The problem is that in group mode to show schedule event menu uses hideDueDate in program stage. But in timeline mode program stage is null because manage all events without program stage reference, in this case always is creating the menu.
I've removed the menu creation in this case

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-
![Screenshot_20240821_110936](https://github.com/user-attachments/assets/08013fc1-90ae-4bd3-93f5-3443d391ff3f)
![Screenshot_20240821_110954](https://github.com/user-attachments/assets/7d4590fc-fa69-465b-b98b-5d962012b82c)

