### PR TITLE
[SPOCC] Hide schedule menu in timeline view

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/domain/GetNewEventCreationTypeOptions.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/domain/GetNewEventCreationTypeOptions.kt
@@ -17,11 +17,19 @@ class GetNewEventCreationTypeOptions(
     ): List<EventCreationType> {
         val options: MutableList<EventCreationType> = mutableListOf()
 
+        // EyeSeeTea customization - Not show schedule events when programStage is null
+        // (timeline events view)
+    /*    programStage?.let {
+            if (shouldShowScheduleEvents(it)) {
+                options.add(SCHEDULE)
+            }
+        } ?: options.add(SCHEDULE)*/
+
         programStage?.let {
             if (shouldShowScheduleEvents(it)) {
                 options.add(SCHEDULE)
             }
-        } ?: options.add(SCHEDULE)
+        }
 
         options.add(ADDNEW)
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/8695n801n #8695n801n
* **Related Pull request:** 


###   :gear: branches 
**app**: 
       Origin: feature-spocc/hide_schedule_event_in_timeline_mode Target: develop-spocc
**dhis2-android-SDK**: 
       Origin: develop-eyeseetea

### :tophat: What is the goal?

Only visible add new in timeline mode

### :memo: How is it being implemented?

- [x] Hardcode to hide schedule in timeline mode

### :boom: How can it be tested?

To hide referrals works in all modes setting from android web app

To hide Schedule use hideDueDate in program stage. But in timeline mode program stage is null because manage all events without program stage reference, in this case always was creating the menu.
I've removed the menu creation in this case

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

