### PR TITLE
Fix for slow counting of org units for search results

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
@@ -980,7 +980,7 @@ public class SearchRepositoryImpl implements SearchRepository {
     private boolean displayOrgUnit() {
         return d2.organisationUnitModule().organisationUnits()
                 .byProgramUids(Collections.singletonList(currentProgram))
-                .blockingGet().size() > 1;
+                .count().blockingGet() > 1;
     }
 
     // EyeSeeTea customizations


### PR DESCRIPTION
Please refer to the [PR for the core repo](https://github.com/dhis2/dhis2-android-capture-app/pull/3798) for details on the fix