### PR TITLE
[SPOCC] Fix assign team request status

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataValuePresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataValuePresenter.kt
@@ -32,7 +32,7 @@ import timber.log.Timber
 import kotlin.coroutines.CoroutineContext
 
 //EyeSeeTea customizations
-private const val teamStatusUId = "I1CBbsdTg3A"
+private const val teamRequestStatusUId = "POi3jY1mjJ0"
 private const val teamParentUId = "S5Hb8en5OJU"
 private const val teamSDSUid = "aml0insfFuA"
 
@@ -308,7 +308,10 @@ class DataValuePresenter(
             } else {
                 errors.remove(cell.id!!)
             }
-            updateData(catComboUid!!)
+
+            if (catComboUid != null){
+                updateData(catComboUid)
+            }
         }
     }
 
@@ -328,13 +331,8 @@ class DataValuePresenter(
         tableDimensionStore.saveTableWidth(tableId, widthDpValue)
     }
 
+    // EyeSeeTea customizations
     fun createTeamChangeRequest() {
-        val teamStatusCell = screenState.value.tables[0].findCell(teamStatusUId)
-
-        if (teamStatusCell != null) {
-            onSaveValueChange(teamStatusCell.copy(value = "Active"))
-        }
-
         val teamParentCell = screenState.value.tables[0].findCell(teamParentUId)
 
         if (teamParentCell != null) {
@@ -342,6 +340,9 @@ class DataValuePresenter(
 
             onSaveValueChange(teamParentCell.copy(value = parentOrgUnit))
         }
+
+        val requestStatusCell = TableCell(id= "${teamRequestStatusUId}_HllvX50cXC0", value = "REQUESTED", column = 0, row = 0)
+        onSaveValueChange(requestStatusCell)
     }
 
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/8693yr54b #8693yr54b
* **Related Pull request:** 


###   :gear: branches 
**app**: 
       Origin: feature-spocc/fix_assign_team_request_status Target: develop-spocc
**dhis2-android-SDK**: 
       Origin: adaf640198be3280bc98b2eb743766c18a0260c8

### :tophat: What is the goal?

Fix the creation of team request change

### :memo: How is it being implemented?

- [x] Assign requested to request status data element

### :boom: How can it be tested?

Save a change request and when appear the question "Do you want to create a change request for this team profile?" click on yes and sync with the server.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

