### PR TITLE
[SPOCC] Avoid change org unit in tracker events

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentActivity.kt
@@ -207,6 +207,7 @@ class EnrollmentActivity : ActivityGlobalAbstract(), EnrollmentView {
                 presenter.getEnrollment()!!.uid(),
                 0,
                 presenter.getEnrollment()!!.status(),
+                true
             )
             val eventInitialIntent = Intent(abstracContext, EventInitialActivity::class.java)
             eventInitialIntent.putExtras(bundle)

--- a/app/src/main/java/org/dhis2/usescases/events/ScheduledEventActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/events/ScheduledEventActivity.kt
@@ -260,6 +260,7 @@ class ScheduledEventActivity : ActivityGlobalAbstract(), ScheduledEventContract.
             event.enrollment(),
             stage.standardInterval() ?: 0,
             presenter.getEnrollment()?.status(),
+            true
         )
         startActivity(Intent(this, EventInitialActivity::class.java).apply { putExtras(bundle) })
         finish()

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCapturePagerAdapter.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCapturePagerAdapter.java
@@ -36,7 +36,7 @@ public class EventCapturePagerAdapter extends FragmentStateAdapter {
     private final boolean shouldOpenErrorSection;
 
     public boolean isFormScreenShown(@Nullable Integer currentItem) {
-        return currentItem!=null && pages.get(currentItem) == EventPageType.DATA_ENTRY;
+        return currentItem != null && pages.get(currentItem) == EventPageType.DATA_ENTRY;
     }
 
     private enum EventPageType {

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/providers/InputFieldsProvider.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/providers/InputFieldsProvider.kt
@@ -44,6 +44,7 @@ import org.hisp.dhis.mobile.ui.designsystem.component.InputOrgUnit
 import org.hisp.dhis.mobile.ui.designsystem.component.InputPolygon
 import org.hisp.dhis.mobile.ui.designsystem.component.InputRadioButton
 import org.hisp.dhis.mobile.ui.designsystem.component.InputShellState
+import org.hisp.dhis.mobile.ui.designsystem.component.InputText
 import org.hisp.dhis.mobile.ui.designsystem.component.Orientation
 import org.hisp.dhis.mobile.ui.designsystem.component.RadioButtonData
 import org.hisp.dhis.mobile.ui.designsystem.component.internal.DateTransformation
@@ -182,6 +183,7 @@ fun ProvideOrgUnit(
     onClear: () -> Unit,
     required: Boolean = false,
     showField: Boolean = true,
+    enabled: Boolean = false,
 ) {
     if (showField) {
         Spacer(modifier = Modifier.height(16.dp))
@@ -191,21 +193,36 @@ fun ProvideOrgUnit(
             mutableStateOf(orgUnit.selectedOrgUnit?.displayName())
         }
 
-        InputOrgUnit(
-            title = resources.getString(R.string.org_unit),
-            state = state,
-            inputText = inputFieldValue ?: "",
-            onValueChanged = {
-                inputFieldValue = it
-                if (it.isNullOrEmpty()) {
-                    onClear()
-                }
-            },
-            onOrgUnitActionCLicked = onOrgUnitClick,
-            isRequiredField = required,
-        )
+        if (enabled){
+            InputOrgUnit(
+                title = resources.getString(R.string.org_unit),
+                state = state,
+                inputText = inputFieldValue ?: "",
+                onValueChanged = {
+                    inputFieldValue = it
+                    if (it.isNullOrEmpty()) {
+                        onClear()
+                    }
+                },
+                onOrgUnitActionCLicked = onOrgUnitClick,
+                isRequiredField = required,
+            )
+        }else {
+            InputText(
+                //modifier = modifier.fillMaxWidth(),
+                title = resources.getString(R.string.org_unit),
+                state = InputShellState.DISABLED,
+                //supportingText = fieldUiModel.supportingText(),
+                //legendData = fieldUiModel.legend(),
+                inputText =  inputFieldValue ?: "",
+                isRequiredField = required,
+                //onNextClicked = onNextClicked,
+
+            )
+        }
     }
 }
+
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/ui/EventDetailsFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/ui/EventDetailsFragment.kt
@@ -16,6 +16,8 @@ import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import org.dhis2.R
+import org.dhis2.commons.Constants.DISABLE_SELECT_ORG_UNIT
+
 import org.dhis2.commons.Constants.ENROLLMENT_STATUS
 import org.dhis2.commons.Constants.ENROLLMENT_UID
 import org.dhis2.commons.Constants.EVENT_CREATION_TYPE
@@ -132,6 +134,9 @@ class EventDetailsFragment : FragmentGlobalAbstract() {
                     .getSerializable(ENROLLMENT_STATUS) as EnrollmentStatus?,
             ),
         )?.inject(this)
+
+        val disableSelectOrgUnit = requireArguments().getBoolean(DISABLE_SELECT_ORG_UNIT, false)
+
         binding = DataBindingUtil.inflate(
             inflater,
             R.layout.event_details_fragment,
@@ -155,6 +160,7 @@ class EventDetailsFragment : FragmentGlobalAbstract() {
                 catCombo = catCombo,
                 coordinates = coordinates,
                 eventTemp = eventTemp,
+                enable = !disableSelectOrgUnit
             )
         }
         return binding.root
@@ -243,6 +249,7 @@ class EventDetailsFragment : FragmentGlobalAbstract() {
         catCombo: EventCatCombo,
         coordinates: EventCoordinates,
         eventTemp: EventTemp,
+        enable: Boolean
     ) {
         Column {
             ProvideInputDate(
@@ -258,6 +265,7 @@ class EventDetailsFragment : FragmentGlobalAbstract() {
                     showField = date.active,
                 ),
             )
+
             ProvideOrgUnit(
                 orgUnit = orgUnit,
                 detailsEnabled = details.enabled,
@@ -268,6 +276,7 @@ class EventDetailsFragment : FragmentGlobalAbstract() {
                 },
                 required = true,
                 showField = orgUnit.visible,
+                enabled = enable
             )
 
             if (!catCombo.isDefault && catCombo.categories.isNotEmpty()) {

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialActivity.java
@@ -73,6 +73,7 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
     private String programStageUid;
     private EnrollmentStatus enrollmentStatus;
     private int eventScheduleInterval;
+    private boolean disableSelectOrgUnit;
 
     private ProgramStage programStage;
     private Program program;
@@ -85,7 +86,8 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
 
     public static Bundle getBundle(String programUid, String eventUid, String eventCreationType,
                                    String teiUid, PeriodType eventPeriodType, String orgUnit, String stageUid,
-                                   String enrollmentUid, int eventScheduleInterval, EnrollmentStatus enrollmentStatus) {
+                                   String enrollmentUid, int eventScheduleInterval, EnrollmentStatus enrollmentStatus,
+                                   boolean disableSelectOrgUnit) {
         Bundle bundle = new Bundle();
         bundle.putString(Constants.PROGRAM_UID, programUid);
         bundle.putString(Constants.EVENT_UID, eventUid);
@@ -97,6 +99,7 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
         bundle.putString(Constants.PROGRAM_STAGE_UID, stageUid);
         bundle.putInt(Constants.EVENT_SCHEDULE_INTERVAL, eventScheduleInterval);
         bundle.putSerializable(Constants.ENROLLMENT_STATUS, enrollmentStatus);
+        bundle.putBoolean(Constants.DISABLE_SELECT_ORG_UNIT, disableSelectOrgUnit);
         return bundle;
     }
 
@@ -113,6 +116,7 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
         programStageUid = getIntent().getStringExtra(Constants.PROGRAM_STAGE_UID);
         enrollmentStatus = (EnrollmentStatus) getIntent().getSerializableExtra(Constants.ENROLLMENT_STATUS);
         eventScheduleInterval = getIntent().getIntExtra(Constants.EVENT_SCHEDULE_INTERVAL, 0);
+        disableSelectOrgUnit = getIntent().getBooleanExtra(Constants.DISABLE_SELECT_ORG_UNIT, disableSelectOrgUnit);
     }
 
     @Override
@@ -143,6 +147,7 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
         bundle.putInt(Constants.EVENT_SCHEDULE_INTERVAL, eventScheduleInterval);
         bundle.putString(Constants.ORG_UNIT, selectedOrgUnit);
         bundle.putSerializable(Constants.ENROLLMENT_STATUS, enrollmentStatus);
+        bundle.putBoolean(Constants.DISABLE_SELECT_ORG_UNIT, disableSelectOrgUnit);
 
         EventDetailsFragment eventDetailsFragment = new EventDetailsFragment();
         eventDetailsFragment.setArguments(bundle);

--- a/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventDetailActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventDetailActivity.kt
@@ -303,6 +303,7 @@ class ProgramEventDetailActivity :
             null,
             0,
             null,
+            false
         )
         startActivity(
             EventInitialActivity::class.java,

--- a/app/src/main/java/org/dhis2/usescases/programStageSelection/ProgramStageSelectionActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/programStageSelection/ProgramStageSelectionActivity.kt
@@ -96,6 +96,7 @@ class ProgramStageSelectionActivity : ActivityGlobalAbstract(), ProgramStageSele
                 Constants.EVENT_SCHEDULE_INTERVAL,
                 presenter.getStandardInterval(programStageUid),
             )
+            putBoolean(Constants.DISABLE_SELECT_ORG_UNIT, true)
         }
 
         intent.addFlags(Intent.FLAG_ACTIVITY_FORWARD_RESULT)

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.kt
@@ -564,6 +564,7 @@ class TEIDataFragment : FragmentGlobalAbstract(), TEIDataContracts.View {
         bundle.putSerializable(Constants.EVENT_PERIOD_TYPE, programStage.periodType())
         bundle.putString(Constants.PROGRAM_STAGE_UID, programStage.uid())
         bundle.putInt(Constants.EVENT_SCHEDULE_INTERVAL, programStage.standardInterval() ?: 0)
+        bundle.putBoolean(Constants.DISABLE_SELECT_ORG_UNIT, true)
         intent.putExtras(bundle)
         eventInitialLauncher.launch(intent)
     }

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataPresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataPresenter.kt
@@ -397,6 +397,7 @@ class TEIDataPresenter(
                     dashboardModel?.currentEnrollment?.uid(),
                     0,
                     dashboardModel?.currentEnrollment?.status(),
+                    true
                 ),
             )
             view.openEventInitial(intent)

--- a/commons/src/main/java/org/dhis2/commons/Constants.java
+++ b/commons/src/main/java/org/dhis2/commons/Constants.java
@@ -92,6 +92,7 @@ public class Constants {
     public static final String ENROLLMENT_DATE_UID = "ENROLLMENT_DATE_UID";
     public static final String ENROLLMENT_DATE = "enrollmentDate";
     public static final String INCIDENT_DATE = "incidentDate";
+    public static final String DISABLE_SELECT_ORG_UNIT = "DISABLE_SELECT_ORG_UNIT";
 
     public static final String INITIAL_SYNC = "INITIAL_SYNC";
     public static final String META = "METADATA";


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/8695x3vq0 #8695x3vq0
* **Related Pull request:** 


###   :gear: branches 
**app**: 
       Origin: feature-spocc/avoid_change_org_unit_in_tei_event Target: develop-spocc
**dhis2-android-SDK**: 
       Origin: adaf640198be3280bc98b2eb743766c18a0260c8

### :tophat: What is the goal?

Avoid change or unit in tracker events

### :memo: How is it being implemented?

- [x] Render for tracker events

### :boom: How can it be tested?

Enter in a TEI and create an event then the org unit should be selected and should not be possible to change it

Remember, there are two modes: group by program stage and timeline. In both should not be possible change the org unit to create an event

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

