### PR TITLE
Fix for unwanted deletion of non-synced new TEI when its 2nd enrollment is cancelled

### DIFF
--- a/app/src/main/java/org/dhis2/data/biometrics/utils/IsTeiInNoOtherProgram.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/utils/IsTeiInNoOtherProgram.kt
@@ -1,0 +1,9 @@
+package org.dhis2.data.biometrics.utils
+
+import org.hisp.dhis.android.core.D2
+
+fun isTeiInNoOtherProgram(d2: D2, teiUid: String?, programUid: String?): Boolean =
+    d2.enrollmentModule().enrollments()
+        .byTrackedEntityInstance().eq(teiUid)
+        .byProgram().neq(programUid)
+        .blockingCount() == 0

--- a/app/src/main/java/org/dhis2/data/biometrics/utils/IsTeiInNoOtherProgram.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/utils/IsTeiInNoOtherProgram.kt
@@ -1,9 +1,0 @@
-package org.dhis2.data.biometrics.utils
-
-import org.hisp.dhis.android.core.D2
-
-fun isTeiInNoOtherProgram(d2: D2, teiUid: String?, programUid: String?): Boolean =
-    d2.enrollmentModule().enrollments()
-        .byTrackedEntityInstance().eq(teiUid)
-        .byProgram().neq(programUid)
-        .blockingCount() == 0

--- a/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentPresenterImpl.kt
+++ b/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentPresenterImpl.kt
@@ -242,13 +242,19 @@ class EnrollmentPresenterImpl(
     }
 
     fun deleteAllSavedData() {
-        if (teiRepository.blockingGet()?.syncState() == State.TO_POST) {
+        if (teiRepository.blockingGet()?.syncState() == State.TO_POST && isTeiInNoOtherProgram()) {
             teiRepository.blockingDelete()
         } else {
             enrollmentObjectRepository.blockingDelete()
         }
         analyticsHelper.setEvent(DELETE_AND_BACK, CLICK, DELETE_AND_BACK)
     }
+
+    private fun isTeiInNoOtherProgram(): Boolean =
+        d2.enrollmentModule().enrollments()
+            .byTrackedEntityInstance().eq(teiRepository.blockingGet()?.uid())
+            .byProgram().neq(programRepository.blockingGet()?.uid())
+            .blockingCount() == 0
 
     fun onDettach() {
         disposable.clear()

--- a/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentPresenterImpl.kt
+++ b/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentPresenterImpl.kt
@@ -23,7 +23,6 @@ import org.dhis2.data.biometrics.utils.getBiometricsTrackedEntityAttribute
 import org.dhis2.data.biometrics.utils.getParentBiometricsAttributeValueIfRequired
 import org.dhis2.data.biometrics.utils.getTeiByUid
 import org.dhis2.data.biometrics.utils.getTrackedEntityAttributeValueByAttribute
-import org.dhis2.data.biometrics.utils.isTeiInNoOtherProgram
 import org.dhis2.form.data.EnrollmentRepository
 import org.dhis2.form.model.FieldUiModel
 import org.dhis2.form.model.RowAction
@@ -244,8 +243,7 @@ class EnrollmentPresenterImpl(
 
     fun deleteAllSavedData() {
         val isTeiInNoOtherProgram by lazy {
-            isTeiInNoOtherProgram(
-                d2,
+            dataEntryRepository.isTeiInNoOtherProgram(
                 teiUid = teiRepository.blockingGet()?.uid(),
                 programUid = programRepository.blockingGet()?.uid(),
             )

--- a/app/src/test/java/org/dhis2/usescases/enrollment/EnrollmentPresenterImplTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/enrollment/EnrollmentPresenterImplTest.kt
@@ -254,7 +254,7 @@ class EnrollmentPresenterImplTest {
         val programUid = "programUid"
         givenATei(teiUid, State.TO_POST)
         givenAProgram(programUid)
-        givenEnrollmentCount(teiUid, programUid, count = 0)
+        givenTeiInNoOtherProgram(teiUid, programUid, true)
 
         presenter.deleteAllSavedData()
 
@@ -268,7 +268,7 @@ class EnrollmentPresenterImplTest {
         val programUid = "programUid"
         givenATei(teiUid, State.TO_POST)
         givenAProgram(programUid)
-        givenEnrollmentCount(teiUid, programUid, count = 1)
+        givenTeiInNoOtherProgram(teiUid, programUid, false)
 
         presenter.deleteAllSavedData()
 
@@ -300,22 +300,7 @@ class EnrollmentPresenterImplTest {
         whenever(programRepository.blockingGet()) doReturn program
     }
 
-    private fun givenEnrollmentCount(teiUid: String, programUid: String, count: Int) {
-        whenever(d2.enrollmentModule().enrollments()) doReturn mock()
-        whenever(d2.enrollmentModule().enrollments().byTrackedEntityInstance()) doReturn mock()
-        whenever(
-            d2.enrollmentModule().enrollments().byTrackedEntityInstance().eq(teiUid)
-        ) doReturn mock()
-        whenever(
-            d2.enrollmentModule().enrollments().byTrackedEntityInstance().eq(teiUid).byProgram()
-        ) doReturn mock()
-        whenever(
-            d2.enrollmentModule().enrollments().byTrackedEntityInstance().eq(teiUid).byProgram()
-                .neq(programUid)
-        ) doReturn mock()
-        whenever(
-            d2.enrollmentModule().enrollments().byTrackedEntityInstance().eq(teiUid).byProgram()
-                .neq(programUid).blockingCount()
-        ) doReturn count
+    private fun givenTeiInNoOtherProgram(teiUid: String, programUid: String, value: Boolean) {
+        whenever(dataEntryRepository.isTeiInNoOtherProgram(teiUid, programUid)) doReturn value
     }
 }

--- a/app/src/test/java/org/dhis2/usescases/enrollment/EnrollmentPresenterImplTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/enrollment/EnrollmentPresenterImplTest.kt
@@ -250,30 +250,11 @@ class EnrollmentPresenterImplTest {
 
     @Test
     fun `Should delete TEI in deleteAllSavedData() when sync state is TO_POST and TEI is not in any other program`() {
-        val tei = TrackedEntityInstance.builder()
-            .uid("teiUid")
-            .syncState(State.TO_POST)
-            .build()
-        val program = Program.builder().uid("programUid").build()
-
-        whenever(teiRepository.blockingGet()) doReturn tei
-        whenever(programRepository.blockingGet()) doReturn program
-        whenever(d2.enrollmentModule().enrollments()) doReturn mock()
-        whenever(d2.enrollmentModule().enrollments().byTrackedEntityInstance()) doReturn mock()
-        whenever(
-            d2.enrollmentModule().enrollments().byTrackedEntityInstance().eq("teiUid")
-        ) doReturn mock()
-        whenever(
-            d2.enrollmentModule().enrollments().byTrackedEntityInstance().eq("teiUid").byProgram()
-        ) doReturn mock()
-        whenever(
-            d2.enrollmentModule().enrollments().byTrackedEntityInstance().eq("teiUid").byProgram()
-                .neq("programUid")
-        ) doReturn mock()
-        whenever(
-            d2.enrollmentModule().enrollments().byTrackedEntityInstance().eq("teiUid").byProgram()
-                .neq("programUid").blockingCount()
-        ) doReturn 0
+        val teiUid = "teiUid"
+        val programUid = "programUid"
+        givenATei(teiUid, State.TO_POST)
+        givenAProgram(programUid)
+        givenEnrollmentCount(teiUid, programUid, count = 0)
 
         presenter.deleteAllSavedData()
 
@@ -283,30 +264,11 @@ class EnrollmentPresenterImplTest {
 
     @Test
     fun `Should only delete enrollment in deleteAllSavedData() when TEI is also in another program`() {
-        val tei = TrackedEntityInstance.builder()
-            .uid("teiUid")
-            .syncState(State.TO_POST)
-            .build()
-        val program = Program.builder().uid("programUid").build()
-
-        whenever(teiRepository.blockingGet()) doReturn tei
-        whenever(programRepository.blockingGet()) doReturn program
-        whenever(d2.enrollmentModule().enrollments()) doReturn mock()
-        whenever(d2.enrollmentModule().enrollments().byTrackedEntityInstance()) doReturn mock()
-        whenever(
-            d2.enrollmentModule().enrollments().byTrackedEntityInstance().eq("teiUid")
-        ) doReturn mock()
-        whenever(
-            d2.enrollmentModule().enrollments().byTrackedEntityInstance().eq("teiUid").byProgram()
-        ) doReturn mock()
-        whenever(
-            d2.enrollmentModule().enrollments().byTrackedEntityInstance().eq("teiUid").byProgram()
-                .neq("programUid")
-        ) doReturn mock()
-        whenever(
-            d2.enrollmentModule().enrollments().byTrackedEntityInstance().eq("teiUid").byProgram()
-                .neq("programUid").blockingCount()
-        ) doReturn 1
+        val teiUid = "teiUid"
+        val programUid = "programUid"
+        givenATei(teiUid, State.TO_POST)
+        givenAProgram(programUid)
+        givenEnrollmentCount(teiUid, programUid, count = 1)
 
         presenter.deleteAllSavedData()
 
@@ -316,12 +278,8 @@ class EnrollmentPresenterImplTest {
 
     @Test
     fun `Should only delete enrollment in deleteAllSavedData() when sync state is not TO_POST`() {
-        val tei = TrackedEntityInstance.builder()
-            .uid("teiUid")
-            .syncState(State.SYNCED)
-            .build()
-
-        whenever(teiRepository.blockingGet()) doReturn tei
+        givenATei("teiUid", State.SYNCED)
+        givenAProgram("programUid")
 
         presenter.deleteAllSavedData()
 
@@ -329,4 +287,35 @@ class EnrollmentPresenterImplTest {
         verify(teiRepository, never()).blockingDelete()
     }
 
+    private fun givenATei(uid: String, syncState: State) {
+        val tei = TrackedEntityInstance.builder()
+            .uid(uid)
+            .syncState(syncState)
+            .build()
+        whenever(teiRepository.blockingGet()) doReturn tei
+    }
+
+    private fun givenAProgram(uid: String) {
+        val program = Program.builder().uid(uid).build()
+        whenever(programRepository.blockingGet()) doReturn program
+    }
+
+    private fun givenEnrollmentCount(teiUid: String, programUid: String, count: Int) {
+        whenever(d2.enrollmentModule().enrollments()) doReturn mock()
+        whenever(d2.enrollmentModule().enrollments().byTrackedEntityInstance()) doReturn mock()
+        whenever(
+            d2.enrollmentModule().enrollments().byTrackedEntityInstance().eq(teiUid)
+        ) doReturn mock()
+        whenever(
+            d2.enrollmentModule().enrollments().byTrackedEntityInstance().eq(teiUid).byProgram()
+        ) doReturn mock()
+        whenever(
+            d2.enrollmentModule().enrollments().byTrackedEntityInstance().eq(teiUid).byProgram()
+                .neq(programUid)
+        ) doReturn mock()
+        whenever(
+            d2.enrollmentModule().enrollments().byTrackedEntityInstance().eq(teiUid).byProgram()
+                .neq(programUid).blockingCount()
+        ) doReturn count
+    }
 }

--- a/form/src/main/java/org/dhis2/form/data/EnrollmentRepository.kt
+++ b/form/src/main/java/org/dhis2/form/data/EnrollmentRepository.kt
@@ -524,6 +524,10 @@ class EnrollmentRepository(
         )
     }
 
+    fun isTeiInNoOtherProgram(teiUid: String?, programUid: String?): Boolean {
+        return conf.isTeiInNoOtherProgram(teiUid, programUid)
+    }
+
     fun hasEventsGeneratedByEnrollmentDate(): Boolean {
         return conf.hasEventsGeneratedByEnrollmentDate()
     }

--- a/form/src/main/java/org/dhis2/form/data/metadata/EnrollmentConfiguration.kt
+++ b/form/src/main/java/org/dhis2/form/data/metadata/EnrollmentConfiguration.kt
@@ -113,6 +113,12 @@ class EnrollmentConfiguration(
             .blockingIsEmpty()
     }
 
+    fun isTeiInNoOtherProgram(teiUid: String?, programUid: String?): Boolean =
+        d2.enrollmentModule().enrollments()
+            .byTrackedEntityInstance().eq(teiUid)
+            .byProgram().neq(programUid)
+            .blockingCount() == 0
+
     fun setValue(attributeUid: String, value: String) {
         d2.trackedEntityModule().trackedEntityAttributeValues()
             .value(attributeUid, tei()?.uid()!!)


### PR DESCRIPTION
## Description

An issue of the logic of cleanup when a newly created, not synced yet TEI is being enrolled into another program, and the user backs out of the 2nd enrollment screen by discarding the changes in the pop-up bottom sheet dialog. The issue occurred in `app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentPresenterImpl.kt` in `deleteAllSavedData`.

## Solution description

A check is added in `deleteAllSavedData` to delete the entire non-synced TEI only when there are no enrollments in other programs than the one being cancelled.

## Covered unit test cases

Unit tests for the new behavior of `deleteAllSavedData` added to `app/src/test/java/org/dhis2/usescases/enrollment/EnrollmentPresenterImplTest.kt`.