### PR TITLE
[SPOCC] Hide re-open menu always

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/TeiDashboardMobileActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/TeiDashboardMobileActivity.kt
@@ -571,9 +571,14 @@ class TeiDashboardMobileActivity :
                         popupMenu.menu.findItem(R.id.complete).isVisible = false
                     } else if (status == EnrollmentStatus.CANCELLED) {
                         popupMenu.menu.findItem(R.id.deactivate).isVisible = false
-                    } else {
-                        popupMenu.menu.findItem(R.id.activate).isVisible = false
                     }
+                    // EyeSeeTea customization - re-open always not visible
+                    // is not possible re-open completed enrollments
+               /*     else {
+                        popupMenu.menu.findItem(R.id.activate).isVisible = false
+                    }*/
+                    popupMenu.menu.findItem(R.id.activate).isVisible = false
+
                     if (dashboardViewModel.showFollowUpBar.value) {
                         popupMenu.menu.findItem(R.id.markForFollowUp).isVisible = false
                     }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/8695y3mn6 #8695y3mn6
* **Related Pull request:** 


###   :gear: branches 
**app**: 
       Origin: feature-spocc/hide_reopen_menu_alwaysTarget: develop-spocc
**dhis2-android-SDK**: 
       Origin: adaf640198be3280bc98b2eb743766c18a0260c8

### :tophat: What is the goal?

Avoid reopen completed enrollments

### :memo: How is it being implemented?

- [x] Hide re-open menu always

### :boom: How can it be tested?

Complete an enrollment and never should be visible the re-open menu

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

