### PR TITLE
[SPOCC] Optimise get country query and add loader to dialog

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/eventCaptureFragment/upg/data/UPGD2Repository.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/eventCaptureFragment/upg/data/UPGD2Repository.kt
@@ -3,7 +3,10 @@ package org.dhis2.usescases.eventsWithoutRegistration.eventCapture.eventCaptureF
 import org.dhis2.usescases.eventsWithoutRegistration.eventCapture.eventCaptureFragment.upg.domain.UPGItem
 import org.dhis2.usescases.eventsWithoutRegistration.eventCapture.eventCaptureFragment.upg.domain.UPGRepository
 import org.hisp.dhis.android.core.D2
-import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
+
+private const val upgProgram = "lu4r3oPCg6v"
+private const val upgStatusDE = "bCGs7tqWUdd"
+private const val upgNameDE = "rn2YpLCqksT"
 
 class UPGD2Repository(
     private val d2: D2,
@@ -11,52 +14,41 @@ class UPGD2Repository(
 
     override fun get(orgUnitUid: String): List<UPGItem> {
         val countryUid = getCountry(orgUnitUid)
+
         //https://cpr-test.samaritanspurse.org/api/trackedEntityInstances.json?totalPages=true&program=lu4r3oPCg6v&ou=D6eqt1FJ7e8&ouMode=SELECTED&fields=trackedEntityInstance,attributes,enrollments&filter=bCGs7tqWUdd:eq:eligible&pageSize=1000000&skipPaging=false
-        val teis =  d2.trackedEntityModule().trackedEntityInstances()
+        val teis = d2.trackedEntityModule().trackedEntityInstances()
             .withTrackedEntityAttributeValues()
-            .byProgramUids(listOf("lu4r3oPCg6v"))
+            .byProgramUids(listOf(upgProgram))
             .byOrganisationUnitUid().eq(countryUid)
             .get()
             .blockingGet()
 
-            val eligibleTEIS = teis
-            .filter {
-                it.trackedEntityAttributeValues()?.any { attribute ->
-                    attribute.trackedEntityAttribute() == "bCGs7tqWUdd" &&
-                            attribute.value()!!.lowercase() == "eligible"
+        return teis.asSequence()
+            .filter { tei ->
+                tei.trackedEntityAttributeValues()?.any { attribute ->
+                    attribute.trackedEntityAttribute() == upgStatusDE &&
+                            attribute.value()?.lowercase() == "eligible"
                 } ?: false
             }
+            .mapNotNull { tei ->
+                val upgName = tei.trackedEntityAttributeValues()
+                    ?.find { attribute -> attribute.trackedEntityAttribute() == upgNameDE }
+                    ?.value()
 
-            val upgItems = eligibleTEIS
-            .map {
-                val upgUid = it.uid()
-
-                val upgName = it.trackedEntityAttributeValues()
-                    ?.find { attribute -> attribute.trackedEntityAttribute() == "rn2YpLCqksT" }
-                    ?.value() ?: ""
-
-                UPGItem(
-                    upgUid,
-                    upgName
-                )
-            }.filter { it.name.isNotEmpty() }
-
-        return upgItems.sortedBy { it.name }
+                if (upgName.isNullOrEmpty()) null
+                else UPGItem(tei.uid(), upgName)
+            }
+            .sortedBy { it.name }
+            .toList()
     }
 
     private fun getCountry(orgUnitUid: String): String {
-        var orgUnit : OrganisationUnit? = null
-        var parentUid: String = orgUnitUid
+        val orgUnit = d2.organisationUnitModule().organisationUnits().byUid().eq(orgUnitUid).one()
+            .blockingGet()
 
-        while (orgUnit == null || orgUnit.level() != 4){
-            orgUnit = d2.organisationUnitModule().organisationUnits()
-                .byUid().eq(parentUid)
-                .one().blockingGet()
+        val countryUid = orgUnit?.path()?.split("/")?.get(4) ?: ""
 
-            parentUid = orgUnit?.parent()?.uid() ?: ""
-        }
-
-        return orgUnit?.uid() ?:""
+        return countryUid
     }
 }
 

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/eventCaptureFragment/upg/ui/SelectUPGDialog.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/eventCaptureFragment/upg/ui/SelectUPGDialog.kt
@@ -82,6 +82,14 @@ class SelectUPGDialog : DialogFragment(), SelectUPGDialogView {
         dismiss()
     }
 
+    override fun showLoading() {
+        binding.upgProgressBar.visibility = View.VISIBLE
+    }
+
+    override fun hideLoading() {
+        binding.upgProgressBar.visibility = View.GONE
+    }
+
     override fun dismiss() {
         presenter.onDetach()
         if (isDialogShown) {

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/eventCaptureFragment/upg/ui/SelectUPGDialogPresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/eventCaptureFragment/upg/ui/SelectUPGDialogPresenter.kt
@@ -1,12 +1,18 @@
 package org.dhis2.usescases.eventsWithoutRegistration.eventCapture.eventCaptureFragment.upg.ui
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.dhis2.usescases.eventsWithoutRegistration.eventCapture.eventCaptureFragment.upg.domain.GetUPGItems
 import org.dhis2.usescases.eventsWithoutRegistration.eventCapture.eventCaptureFragment.upg.domain.UPGItem
 
 class SelectUPGDialogPresenter(
     private val getUPGItems: GetUPGItems
-) {
-    lateinit var view: SelectUPGDialogView
+) : CoroutineScope by MainScope() {
+    private var view: SelectUPGDialogView? = null
 
     fun init(
         view: SelectUPGDialogView,
@@ -17,15 +23,24 @@ class SelectUPGDialogPresenter(
         loadData(orgUnitUid)
     }
 
-    private fun loadData(orgUnitUid: String) {
-        view.renderList(getUPGItems(orgUnitUid))
+    private fun loadData(orgUnitUid: String)= launch()  {
+        view?.showLoading()
+
+        val items  = withContext(Dispatchers.IO) {  getUPGItems(orgUnitUid)}
+
+
+        view?.renderList(items)
+
+        view?.hideLoading()
     }
 
     fun onDetach() {
+        this.view = null
+        cancel()
 
     }
 
     fun onItemClick(item: UPGItem) {
-        view.onUPGSelected(item)
+        view?.onUPGSelected(item)
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/eventCaptureFragment/upg/ui/SelectUPGDialogView.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/eventCaptureFragment/upg/ui/SelectUPGDialogView.kt
@@ -5,4 +5,6 @@ import org.dhis2.usescases.eventsWithoutRegistration.eventCapture.eventCaptureFr
 interface SelectUPGDialogView {
     fun renderList(liveData: List<UPGItem>)
     fun onUPGSelected(item: UPGItem)
+    fun showLoading()
+    fun hideLoading()
 }

--- a/app/src/main/res/layout/dialog_select_upg.xml
+++ b/app/src/main/res/layout/dialog_select_upg.xml
@@ -36,7 +36,6 @@
                 app:layout_constraintTop_toTopOf="parent"
                 tools:text="Select UPG" />
 
-
             <RelativeLayout
                 android:id="@+id/upg_empty_container"
                 android:layout_width="match_parent"
@@ -70,6 +69,17 @@
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constraintBottom_toTopOf="@id/cancel_button"
                 app:layout_constraintTop_toBottomOf="@id/title" />
+
+            <ProgressBar
+                android:id="@+id/upg_progress_bar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:progressColor="@{@color/colorPrimary}"/>
 
             <Button
                 android:id="@+id/cancel_button"


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/8695y4at6 #8695y4at6
* **Related Pull request:** 


###   :gear: branches 
**app**: 
       Origin: feature-spocc/performance_upg_selector Target: develop-spocc
**dhis2-android-SDK**: 
       Origin: adaf640198be3280bc98b2eb743766c18a0260c8

### :tophat: What is the goal?

Add loader and try inprove performance

### :memo: How is it being implemented?

- [x] Get country uid only using one query
- [x] Add loader

### :boom: How can it be tested?

Complete an enrollment and never should be visible the re-open menu

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

