### PR TITLE
[Simprints] avoid cancel duplicates dialog on touch outside

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/biometrics/duplicates/BiometricsDuplicatesDialog.kt
+++ b/app/src/main/java/org/dhis2/usescases/biometrics/duplicates/BiometricsDuplicatesDialog.kt
@@ -62,6 +62,9 @@ class BiometricsDuplicatesDialog : DialogFragment(), BiometricsDuplicatesDialogV
             requireArguments().getString(TRACKED_ENTITY_TYPE_UID)!!,
             requireArguments().getString(PROGRAM_UID)!!
         )
+
+        dialog.setCanceledOnTouchOutside(false)
+
         return dialog
     }
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:**  https://app.clickup.com/t/8695zzcfa  #8695zzcfa
* **Related Pull request:** 


###   :gear: branches 
**app**: 
       Origin: feature-simprints/avoid_cancel_dialog_on_touch_outside Target: develop-simprints
**dhis2-android-SDK**: 
       Origin: 148a1f72eb93b2382e26e83f340dd32620a66c4e

### :tophat: What is the goal?

Possible duplicates dialogue should not be dismissed when you tap outside it

### :memo: How is it being implemented?

- [x] configure it in the dialog

### :boom: How can it be tested?



### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-