### PR TITLE
[SPOCC] fix create request second time

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTablePresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTablePresenter.kt
@@ -121,19 +121,20 @@ class DataSetTablePresenter(
             } else {
                 view.showValidationRuleDialog()
             }
-        } else if (!isComplete()) {
+        } else  {
             // Eyeseetea customization - Create Team change request
             // view.showSuccessValidationDialog()
-
             val dataset = tableRepository.getDataSet().blockingGet()
 
             if (dataset?.uid() == TEAM_REQUEST_DATASET) {
                 view.showTeamChangeRequestDialog()
             } else {
-                view.showSuccessValidationDialog()
+                if (!isComplete()){
+                    view.showSuccessValidationDialog()
+                } else {
+                    view.saveAndFinish()
+                }
             }
-        } else {
-            view.saveAndFinish()
         }
     }
 
@@ -233,11 +234,19 @@ class DataSetTablePresenter(
         //Create change request
         onCreateTeamChangeRequestListener?.invoke()
 
-        view.showSuccessValidationDialog()
+        if (!isComplete()){
+            view.showSuccessValidationDialog()
+        } else {
+            view.saveAndFinish()
+        }
     }
 
     fun cancelChangeRequest() {
-        view.showSuccessValidationDialog()
+        if (!isComplete()){
+            view.showSuccessValidationDialog()
+        } else {
+            view.saveAndFinish()
+        }
     }
 
     fun setCreateTeamChangeRequestListener(listener: () -> Unit) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 ndk = "21.4.7075529"
 sdk = "34"
 minSdk = "21"
-vCode = "132"
-vName = "2.9.1.1-spOCC-fork-3"
+vCode = "133"
+vName = "2.9.1.1-spOCC-fork-4"
 kotlinCompilerExtensionVersion = "1.5.6"
 gradle = "8.2.0"
 kotlin = '1.9.21'


### PR DESCRIPTION
### :pushpin: References
* **Issue:**  https://app.clickup.com/t/86964a5zt #86964a5zt
* **Related Pull request:** 

###   :gear: branches 
**app**: 
       Origin: feature-spocc/fix_create_request_second_time Target: develop-spocc
**dhis2-android-SDK**: 
       Origin: afc8d608e4db47d23b83cb8b487061392d0e5bbb

### :tophat: What is the goal?

Fix edit team request second time from the app not working

### :memo: How is it being implemented?

- [x] Show message to create request even when the entry is completed
- [x] Enable save dataValues by repository using d2

### :boom: How can it be tested?

1- Create event to create team change request, save, answer yes to create team request and to complete.

2 - Sync

3- Approve or reject in the server

4 - Edit event and change somthing then save, answer yes to create team request.

The app should send all data values with value again to the server

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-