### PR TITLE
[SPIP]Avoid resize to take photo

### DIFF
--- a/commons/src/main/java/org/dhis2/commons/bindings/FileExtensions.kt
+++ b/commons/src/main/java/org/dhis2/commons/bindings/FileExtensions.kt
@@ -39,7 +39,8 @@ fun File.rotateImage(context: Context): File {
         ei.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
     var bitmap = BitmapFactory.decodeFile(
         this.path,
-        BitmapFactory.Options().apply { inSampleSize = 4 },
+        // EyeSeeTea - Avoid resize
+        //BitmapFactory.Options().apply { inSampleSize = 4 },
     )
 
     bitmap = when (orientation) {
@@ -51,8 +52,9 @@ fun File.rotateImage(context: Context): File {
 
     return File(
         FileResourceDirectoryHelper.getFileResourceDirectory(context),
-        "tempFile.png",
-    ).apply { writeBitmap(bitmap, Bitmap.CompressFormat.JPEG, 100) }
+        "tempFile.jpg",
+    )//   // EyeSeeTea - Avoid resize
+    // .apply { writeBitmap(bitmap, Bitmap.CompressFormat.JPEG, 100) }
 }
 
 private fun rotateImage(source: Bitmap, angle: Float): Bitmap? {

--- a/commons/src/main/java/org/dhis2/commons/bindings/FileExtensions.kt
+++ b/commons/src/main/java/org/dhis2/commons/bindings/FileExtensions.kt
@@ -53,8 +53,7 @@ fun File.rotateImage(context: Context): File {
     return File(
         FileResourceDirectoryHelper.getFileResourceDirectory(context),
         "tempFile.jpg",
-    )//   // EyeSeeTea - Avoid resize
-    // .apply { writeBitmap(bitmap, Bitmap.CompressFormat.JPEG, 100) }
+    ).apply { writeBitmap(bitmap, Bitmap.CompressFormat.JPEG, 100) }
 }
 
 private fun rotateImage(source: Bitmap, angle: Float): Bitmap? {

--- a/form/src/main/java/org/dhis2/form/ui/FormView.kt
+++ b/form/src/main/java/org/dhis2/form/ui/FormView.kt
@@ -201,8 +201,7 @@ class FormView : Fragment() {
                 val imageFile = File(
                     FileResourceDirectoryHelper.getFileResourceDirectory(requireContext()),
                     TEMP_FILE_IMAGE,
-                )// Eyeseetea customization - Avoid resize the image to take photo
-                //.rotateImage(requireContext())
+                ).rotateImage(requireContext())
 
                 onSavePicture?.invoke(imageFile.path)
 

--- a/form/src/main/java/org/dhis2/form/ui/FormView.kt
+++ b/form/src/main/java/org/dhis2/form/ui/FormView.kt
@@ -200,8 +200,10 @@ class FormView : Fragment() {
             if (success) {
                 val imageFile = File(
                     FileResourceDirectoryHelper.getFileResourceDirectory(requireContext()),
-                    TEMP_FILE,
-                ).rotateImage(requireContext())
+                    TEMP_FILE_IMAGE,
+                )// Eyeseetea customization - Avoid resize the image to take photo
+                //.rotateImage(requireContext())
+
                 onSavePicture?.invoke(imageFile.path)
 
                 viewModel.getFocusedItemUid()?.let {
@@ -940,7 +942,7 @@ class FormView : Fragment() {
                                     FileResourceDirectoryHelper.getFileResourceDirectory(
                                         requireContext(),
                                     ),
-                                    TEMP_FILE,
+                                    TEMP_FILE_IMAGE,
                                 ),
                             )
                             takePicture.launch(photoUri)
@@ -1077,7 +1079,7 @@ class FormView : Fragment() {
         SignatureDialog(uiEvent.label) {
             val file = File(
                 FileResourceDirectoryHelper.getFileResourceDirectory(requireContext()),
-                TEMP_FILE,
+                TEMP_FILE_SIGNATURE,
             )
             file.outputStream().use { out ->
                 it.compress(Bitmap.CompressFormat.PNG, 85, out)
@@ -1282,6 +1284,7 @@ class FormView : Fragment() {
 
     companion object {
         const val RECORDS = "RECORDS"
-        const val TEMP_FILE = "tempFile.png"
+        const val TEMP_FILE_SIGNATURE = "tempFile.png"
+        const val TEMP_FILE_IMAGE = "tempFile.jpg"
     }
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/8693ntn2e #8693ntn2e
* **Related Pull request:** 

###   :gear: branches 
**app**: 
       Origin: feature-spip/avoid_resize_to_take_photo Target: develop-spip
**dhis2-android-SDK**: 
       Origin: develop-eyeseetea_1_9_1

### :tophat: What is the goal?

Avoid resize to take photo

### :memo: How is it being implemented?

- [x] Comment call to rotate function that provoke resize

### :boom: How can it be tested?


### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-
