### PR TITLE
Jump-to-top (UX enhancement) when new TEI inserted at the top of TEI list

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/listView/SearchTEList.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/listView/SearchTEList.kt
@@ -173,6 +173,13 @@ class SearchTEList : FragmentGlobalAbstract() {
                     }
                 }
             })
+            liveAdapter.registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
+                override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
+                    if (positionStart == 0) {
+                        scrollToPosition(0)
+                    }
+                }
+            })
         }.also {
             recycler = it
         }


### PR DESCRIPTION
#### Behavior before these changes

* When the user returns to the TEI list after creating a new TEI record, the new TEI is added on top of the list.
* But the position of the list does not change.
* Without scrolling to the top of the list manually, the user cannot see that the TEI record was actually added to the list.

#### Behavior after the changes

* When the user returns to the TEI list after creating a new TEI record, the new TEI is added on top of the list.
* The list auto-scrolls to the top, revealing the newly added TEI record to the user.