### PR TITLE
Progress bars fixed for TEI list and Program stage loading

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureActivity.kt
@@ -123,7 +123,9 @@ class EventCaptureActivity :
                 } else {
                     binding.syncButton.visibility = View.GONE
                 }
-                if (position != 1) {
+                val isPageHandlingProgress =
+                    adapter?.isFormScreenShown(position) == true // form screen handles loading
+                if (position != 1 && !isPageHandlingProgress) {
                     hideProgress()
                 }
             }

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.java
@@ -699,10 +699,18 @@ public class SearchTEActivity extends ActivityGlobalAbstract implements SearchTE
     private void observeMapLoading() {
         viewModel.getRefreshData().observe(this, refresh -> {
             if (currentContent == Content.MAP) {
-                binding.toolbarProgress.show();
+                showProgress();
             }
         });
-        viewModel.getMapResults().observe(this, result -> binding.toolbarProgress.hide());
+        viewModel.getMapResults().observe(this, result -> hideProgress());
+    }
+
+    public void showProgress() {
+        binding.toolbarProgress.show();
+    }
+
+    public void hideProgress() {
+        binding.toolbarProgress.hide();
     }
 
     @Override

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/listView/SearchTEList.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/listView/SearchTEList.kt
@@ -363,6 +363,7 @@ class SearchTEList : FragmentGlobalAbstract() {
             },
             onlineErrorCode = liveAdapter.snapshot().items.lastOrNull()?.onlineErrorCode,
         )
+        (context as SearchTEActivity).hideProgress()
     }
 
     private fun onGlobalDataLoaded() {
@@ -370,6 +371,7 @@ class SearchTEList : FragmentGlobalAbstract() {
             programResultCount = liveAdapter.itemCount,
             globalResultCount = globalAdapter.itemCount,
         )
+        (context as SearchTEActivity).hideProgress()
     }
 
     private fun initGlobalData() {
@@ -394,6 +396,7 @@ class SearchTEList : FragmentGlobalAbstract() {
                 listOf(SearchResult(SearchResult.SearchResultType.LOADING)),
             )
         }
+        (context as SearchTEActivity).showProgress()
     }
 
     private fun initLoading(result: List<SearchResult>?) {

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -32,6 +32,7 @@
             android:layout_height="?android:attr/actionBarSize"
             android:background="?colorPrimary"
             android:gravity="center_vertical"
+            android:clipToPadding="false"
             android:paddingHorizontal="8dp">
 
             <ImageButton
@@ -131,6 +132,7 @@
                 android:layout_height="wrap_content"
                 android:indeterminate="true"
                 android:padding="0dp"
+                android:layout_marginHorizontal="-8dp"
                 android:visibility="gone"
                 app:layout_constraintTop_toBottomOf="@id/guideline"
                 tools:visibility="visible" />


### PR DESCRIPTION
#### Behavior before these changes

* When user navigates back to TEI list after creating a new TEI record, the list may take a few moments to update. If the bottom of the list is out of view, user cannot see the circular loading indicator under the list. Data appears being stuck in an outdated state then, this may be confusing.
* When user starts adding a new program stage on large DHIS2 instances, forms may take a noticeably significant time to load. The linear loading indicator on the bottom of the title bar then typically disappears before the forms finish loading. User then sees a blank screen without loading indication, this may be confusing.

#### Behavior after the changes

* When user navigates back to TEI list after creating a new TEI record, the linear loading indicator on the bottom of the title bar shows that the list is being refreshed.
* When user starts adding a new program stage on large DHIS2 instances, the linear loading indicator on the bottom of the title bar stays visible until the forms finish loading and appear on screen.