### PR TITLE
[Simprints] Unify look and feel buttons in search result screen and search helper

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/biometrics/ui/SearchHelperFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/biometrics/ui/SearchHelperFragment.kt
@@ -6,38 +6,25 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Surface
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import org.dhis2.R
-import org.dhis2.commons.biometrics.gradientButtonColor
+import org.dhis2.usescases.biometrics.ui.buttons.RegisterNewPatientButton
+import org.dhis2.usescases.biometrics.ui.buttons.SearchWithAttributesButton
+import org.dhis2.usescases.biometrics.ui.buttons.SearchWithBiometricsButton
 import org.dhis2.usescases.searchTrackEntity.SearchTEActivity
 import org.dhis2.usescases.searchTrackEntity.SearchTEIViewModel
 import org.dhis2.usescases.searchTrackEntity.SearchTeiViewModelFactory
@@ -77,79 +64,23 @@ fun SearchHelperContent(onAction: (action: SequentialSearchAction) -> Unit = { }
     Surface(color = Color.White) {
         Box(contentAlignment = Alignment.Center, modifier = Modifier.padding(16.dp)) {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                SearchWithBiometricsButton(
+                SearchWithBiometricsButton( Modifier.fillMaxWidth(),
                     onClick = { onAction(SequentialSearchAction.SearchWithBiometrics) })
 
                 Spacer(modifier = Modifier.height(16.dp))
 
-                SearchWithAttributesButton(
+                SearchWithAttributesButton( Modifier.fillMaxWidth(),
                     onClick = { onAction(SequentialSearchAction.SearchWithAttributes) })
 
                 Spacer(modifier = Modifier.height(64.dp))
 
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text("New patient?")
-                    TextButton(
-                        onClick = { onAction(SequentialSearchAction.RegisterNew) }) {
-                        Text(
-                            "Register",
-                            color = Color(0xFF0281cb),
-                            style = TextStyle(
-                                textDecoration = TextDecoration.Underline,
-                                fontWeight = FontWeight.Bold
-                            )
-                        )
-                    }
-                }
+                RegisterNewPatientButton(
+                    onClick = { onAction(SequentialSearchAction.RegisterNew) })
 
             }
         }
     }
 }
-
-@Composable
-fun SearchWithBiometricsButton(
-    onClick: () -> Unit = { },
-) {
-    val modifier = Modifier
-        .wrapContentWidth()
-        .fillMaxWidth()
-        .height(50.dp)
-
-    Button(
-        modifier = modifier,
-        colors = ButtonDefaults.buttonColors(backgroundColor = Color.Transparent),
-        contentPadding = PaddingValues(),
-        onClick = { onClick() },
-    ) {
-        Box(
-            modifier = Modifier
-                .background(gradientButtonColor)
-                .then(modifier),
-            contentAlignment = Alignment.Center,
-
-            ) {
-            Row() {
-                Text(text = "Search with biometrics", color = Color.White)
-            }
-        }
-    }
-}
-
-@Composable
-fun SearchWithAttributesButton(
-    onClick: () -> Unit = { },
-) {
-    OutlinedButton(modifier = Modifier.fillMaxWidth().height(50.dp),
-        border = BorderStroke(
-            width = 1.dp,
-            color = Color(0xFF0281cb)
-        ),
-        onClick = onClick) {
-        Text(stringResource(R.string.search_with_attributes), color = Color(0xFF0281cb))
-    }
-}
-
 
 @Preview
 @Composable

--- a/app/src/main/java/org/dhis2/usescases/biometrics/ui/SequentialNextSearchAction.kt
+++ b/app/src/main/java/org/dhis2/usescases/biometrics/ui/SequentialNextSearchAction.kt
@@ -1,43 +1,30 @@
 package org.dhis2.usescases.biometrics.ui
 
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.Icon
-import androidx.compose.material.OutlinedButton
-import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import org.dhis2.R
-import org.dhis2.commons.biometrics.gradientButtonColor
+import org.dhis2.usescases.biometrics.ui.buttons.RegisterNewPatientButton
+import org.dhis2.usescases.biometrics.ui.buttons.SearchWithAttributesButton
+import org.dhis2.usescases.biometrics.ui.buttons.SearchWithBiometricsButton
 
 @Composable
 internal fun SequentialNextSearchActions(
     sequentialSearchActions: List<SequentialSearchAction>,
     onClick: ((action:SequentialSearchAction) -> Unit),
 ) {
-   Column {
+   Column (horizontalAlignment = Alignment.CenterHorizontally) {
         sequentialSearchActions.forEach { action ->
             SequentialNextSearchAction(
                 sequentialSearchAction = action,
                 onClick = onClick,
             )
-            Spacer(modifier = Modifier.size(8.dp))
+            Spacer(modifier = Modifier.size(12.dp))
         }
     }
 }
@@ -49,62 +36,23 @@ internal fun SequentialNextSearchAction(
 ) {
     when (sequentialSearchAction) {
         is SequentialSearchAction.SearchWithBiometrics -> {
-            OutlinedButton(
+            SearchWithBiometricsButton(
                 modifier = Modifier.defaultMinSize(minHeight = 50.dp, minWidth = 270.dp),
-                border = BorderStroke(
-                    width = 1.dp,
-                    color = Color(0xFF0281cb)
-                ),
-                onClick = { onClick(sequentialSearchAction) }
-            ) {
-                Text(stringResource(R.string.biometrics_search), color = Color(0xFF0281cb))
-            }
+                onClick = { onClick(sequentialSearchAction) },
+            )
         }
 
         is SequentialSearchAction.SearchWithAttributes -> {
-            OutlinedButton(
+            SearchWithAttributesButton(
                 modifier = Modifier.defaultMinSize(minHeight = 50.dp, minWidth = 270.dp),
-                border = BorderStroke(
-                    width = 1.dp,
-                    color = Color(0xFF0281cb)
-                ),
-                onClick = { onClick(sequentialSearchAction) }
-            ) {
-                Text(stringResource(R.string.search_with_attributes), color = Color(0xFF0281cb))
-            }
+                onClick = { onClick(sequentialSearchAction) },
+            )
         }
 
         is SequentialSearchAction.RegisterNew -> {
-            val modifier = Modifier
-                .defaultMinSize(minHeight = 50.dp, minWidth = 270.dp)
-
-            Button(
-                modifier = modifier,
-                colors = ButtonDefaults.buttonColors(backgroundColor = Color.Transparent),
-                contentPadding = PaddingValues(),
+            RegisterNewPatientButton(
                 onClick = { onClick(sequentialSearchAction) },
-            ) {
-                Box(
-                    modifier = Modifier
-                        .background(gradientButtonColor)
-                        .then(modifier),
-                    contentAlignment = Alignment.Center,
-
-                    ) {
-                    Row (verticalAlignment = Alignment.CenterVertically) {
-                        Icon(
-                            imageVector = Icons.Filled.Add,
-                            contentDescription = stringResource(R.string.register_new_patient),
-                            tint = Color.White,
-                        )
-                        Spacer(modifier = Modifier.size(8.dp))
-                        Text(
-                            text = stringResource(R.string.register_new_patient),
-                            color = Color.White,
-                        )
-                    }
-                }
-            }
+            )
         }
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/biometrics/ui/buttons/RegisterNewPatientButton.kt
+++ b/app/src/main/java/org/dhis2/usescases/biometrics/ui/buttons/RegisterNewPatientButton.kt
@@ -1,0 +1,30 @@
+package org.dhis2.usescases.biometrics.ui.buttons
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+
+@Composable
+fun RegisterNewPatientButton(
+    onClick: () -> Unit = { },
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text("New patient?")
+        TextButton(onClick =onClick) {
+            Text(
+                "Register",
+                color = Color(0xFF0281cb),
+                style = TextStyle(
+                    textDecoration = TextDecoration.Underline,
+                    fontWeight = FontWeight.Bold
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/dhis2/usescases/biometrics/ui/buttons/SearchWithAttributesButton.kt
+++ b/app/src/main/java/org/dhis2/usescases/biometrics/ui/buttons/SearchWithAttributesButton.kt
@@ -1,0 +1,27 @@
+package org.dhis2.usescases.biometrics.ui.buttons
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.dhis2.R
+
+@Composable
+fun SearchWithAttributesButton(
+    modifier: Modifier,
+    onClick: () -> Unit = { },
+) {
+    OutlinedButton(modifier = modifier.height(50.dp),
+        border = BorderStroke(
+            width = 1.dp,
+            color = Color(0xFF0281cb)
+        ),
+        onClick = onClick) {
+        Text(stringResource(R.string.search_with_attributes), color = Color(0xFF0281cb))
+    }
+}

--- a/app/src/main/java/org/dhis2/usescases/biometrics/ui/buttons/SearchWithBiometricsButton.kt
+++ b/app/src/main/java/org/dhis2/usescases/biometrics/ui/buttons/SearchWithBiometricsButton.kt
@@ -1,0 +1,48 @@
+package org.dhis2.usescases.biometrics.ui.buttons
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.dhis2.R
+import org.dhis2.commons.biometrics.gradientButtonColor
+
+@Composable
+fun SearchWithBiometricsButton(
+    modifier: Modifier,
+    onClick: () -> Unit = { }
+) {
+    val modifier = modifier
+        .wrapContentWidth()
+        .height(50.dp)
+
+    Button(
+        modifier = modifier,
+        colors = ButtonDefaults.buttonColors(backgroundColor = Color.Transparent),
+        contentPadding = PaddingValues(),
+        onClick = { onClick() },
+    ) {
+        Box(
+            modifier = Modifier
+                .background(gradientButtonColor)
+                .then(modifier),
+            contentAlignment = Alignment.Center,
+
+            ) {
+            Row() {
+                Text(text = stringResource(R.string.biometrics_search), color = Color.White)
+            }
+        }
+    }
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:**  https://app.clickup.com/t/8696kqb43 #8696kqb43
* **Related Pull request:** 

###   :gear: branches 
**app**: 
       Origin: feature-simprints/crashes Target: develop-simprints
**dhis2-android-SDK**: 
       Origin: 148a1f72eb93b2382e26e83f340dd32620a66c4e

### :tophat: What is the goal?

Step 1. Search with Personal Details 
Step 2. Not found 
Step 3 Results not found screen - Search with biometrics & Register New Button displayed 

The look of the Register New Patient is too prominent, it should look the same as New Patient? Register link looking button (included in the start search screen)

### :memo: How is it being implemented?

- [x] Unify look and feel buttons in search result screen and search helper

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-