### PR TITLE
[Simprints] Duplicates dialog button gets cut off

### DIFF
--- a/app/src/main/res/layout/dialog_biometrics_duplicates.xml
+++ b/app/src/main/res/layout/dialog_biometrics_duplicates.xml
@@ -75,29 +75,30 @@
             <Button
                 android:id="@+id/enroll_without_biometrics_button"
                 style="?borderlessButtonStyle"
-                android:layout_width="wrap_content"
-                android:layout_height="40dp"
-                android:layout_gravity="end"
-                android:layout_margin="16dp"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="0dp"
                 android:background="@android:color/transparent"
                 android:text="@string/biometrics_enroll_without_biometrics"
                 android:textColor="@color/colorGreyDefault"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintEnd_toStartOf="@+id/enroll_new_button" />
+                app:layout_constraintEnd_toStartOf="@+id/enroll_new_button"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintWidth_percent="0.5" />
 
             <Button
                 android:id="@+id/enroll_new_button"
                 style="?borderlessButtonStyle"
-                android:layout_width="wrap_content"
-                android:layout_height="40dp"
-                android:layout_gravity="end"
-                android:layout_margin="16dp"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="0dp"
                 android:background="@android:color/transparent"
                 android:text="@string/biometrics_enroll_new"
                 android:textColor="@color/colorGreyDefault"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/enroll_without_biometrics_button"
+                app:layout_constraintWidth_percent="0.45" />
 
 
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -993,7 +993,7 @@
     <string name="biometrics_verification_failed">Declined</string>
     <string name="biometrics_none_of_the_above">None of the above</string>
     <string name="biometrics_enroll_last_biometrics">Enroll last</string>
-    <string name="biometrics_enroll_new">Enroll new biometrics</string>
+    <string name="biometrics_enroll_new">Enrol new biometrics</string>
     <string name="biometrics_possible_duplicates">Possible duplicates</string>
     <string name="biometrics_duplicates_empty_message">Duplicate record not found.</string>
     <string name="biometrics_retake">Retake</string>


### PR DESCRIPTION
### :pushpin: References
* **Issue:**  https://app.clickup.com/t/8696kq9zg #8696kq9zg
* **Related Pull request:** 

###   :gear: branches 
**app**: 
       Origin: feature-simprints/dialog_buttons_cut Target: develop-simprints
**dhis2-android-SDK**: 
       Origin: 148a1f72eb93b2382e26e83f340dd32620a66c4e

### :tophat: What is the goal?

In the duplicates pop up screen, the Enrol without Biometrics button gets cut off and is not visible correctly

### :memo: How is it being implemented?

- [x] Fix buttons design to avoid cut the text in small devices

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-