### PR TITLE
[Simprints] Autoverify TEI to navigate to a duplicate patient

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/biometrics/duplicates/BiometricsDuplicatesDialogPresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/biometrics/duplicates/BiometricsDuplicatesDialogPresenter.kt
@@ -93,6 +93,7 @@ class BiometricsDuplicatesDialogPresenter(
     fun onTEIClick(teiUid: String, enrollmentUid: String, isOnline: Boolean) {
         if (!identityConfirmed) {
             identityConfirmed = true
+
             sendBiometricsConfirmIdentity(teiUid, enrollmentUid, isOnline)
         } else {
             if (!isOnline) {
@@ -112,6 +113,9 @@ class BiometricsDuplicatesDialogPresenter(
             .withTrackedEntityAttributeValues().uid(teiUid).blockingGet()?:return
 
         val guid: String = getBiometricsValueFromTEI(tei) ?: ""
+
+        searchRepository.updateAttributeValue(teiUid, biometricsAttributeUid, guid)
+
         view.sendBiometricsConfirmIdentity(
             biometricsSessionId,
             guid,


### PR DESCRIPTION
### :pushpin: References
* **Issue:**  https://app.clickup.com/t/8696kqnv1 #8696kqnv1
* **Related Pull request:** 

###   :gear: branches 
**app**: 
       Origin: feature-simprints/auto_verify_to_navigate_to_a_duplicate Target: develop-simprints
**dhis2-android-SDK**: 
       Origin: 148a1f72eb93b2382e26e83f340dd32620a66c4e

### :tophat: What is the goal?
Register New-->Enroll biometrics--->possible duplicate--->Select duplicate

Didn't get the biometrics verified flag and instead an active Verify button. Biometrics should be auto verified since biometrics was already captured. 

- [x] Save biometrics attribute to select a duplicate

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-