### PR TITLE
[Simprints] Fix global sync

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/main/HomeRepositoryImpl.kt
+++ b/app/src/main/java/org/dhis2/usescases/main/HomeRepositoryImpl.kt
@@ -127,10 +127,19 @@ class HomeRepositoryImpl(
         }
     }
 
+    /**
+     * Deletes a biometric attribute value for a given tracked entity instance
+     * Used to clean up corrupted or invalid biometric data
+     *
+     * @param teiUid The tracked entity instance UID
+     * @param biometricUid The biometric attribute UID
+     */
     private fun deleteBiometricsAttributeValue(teiUid: String, biometricUid: String) {
         val valueRepository = d2.trackedEntityModule().trackedEntityAttributeValues()
             .value(biometricUid, teiUid)
 
+        Timber.d("Deleting biometric value for TEI: $teiUid and attribute: $biometricUid")
         valueRepository.blockingDelete()
+        Timber.d("Successfully deleted biometric value")
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/main/HomeRepositoryImpl.kt
+++ b/app/src/main/java/org/dhis2/usescases/main/HomeRepositoryImpl.kt
@@ -37,7 +37,8 @@ class HomeRepositoryImpl(
 
         val corruptedBiometricsValues = teiAttributeValues.filter {
             it.value()?.startsWith(BIOMETRICS_SEARCH_PATTERN) == true ||
-                    it.value()?.startsWith(BIOMETRICS_FAILURE_PATTERN) == true
+                    it.value()?.startsWith(BIOMETRICS_FAILURE_PATTERN) == true ||
+                    it.value().isNullOrEmpty()
         }
 
         corruptedBiometricsValues.forEach {
@@ -126,7 +127,7 @@ class HomeRepositoryImpl(
         }
     }
 
-    fun deleteBiometricsAttributeValue(teiUid: String, biometricUid: String) {
+    private fun deleteBiometricsAttributeValue(teiUid: String, biometricUid: String) {
         val valueRepository = d2.trackedEntityModule().trackedEntityAttributeValues()
             .value(biometricUid, teiUid)
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:**  https://app.clickup.com/t/8696qq0ta #8696qq0ta
* **Related Pull request:** 

###   :gear: branches 
**app**: 
       Origin: feature-simprints/global_sync Target: develop-simprints
**dhis2-android-SDK**: 
       Origin: 148a1f72eb93b2382e26e83f340dd32620a66c4e

### :tophat: What is the goal?
When clicking the sync button on the top toolbar (rather than the individual record sync buttons), I would expect the unsynced records to sync. 
The records don't sync with global sync, but do with individual sync

### :memo: How is it being implemented?

- [x] Fix global sync

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-