### PR TITLE
Getting TEI full name parts from all attributes in biometric result confirmation dialog

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/ui/mapper/TEICardMapper.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/ui/mapper/TEICardMapper.kt
@@ -484,23 +484,23 @@ class TEICardMapper(
     }
 
     private fun getConfirmationDialogTitle(item: SearchTeiModel): String {
-        return if (item.attributeValues.isEmpty()) {
-            "-"
-        } else {
-            val firsNameValue =
-                item.attributeValues.values.firstOrNull { it.trackedEntityAttribute() == firstNameAttrUid }
-                    ?.value()
+        val firsNameValue =
+            item.allAttributeValues.values.firstOrNull { it.trackedEntityAttribute() == firstNameAttrUid }
+                ?.value()
 
-            val middleNameValue =
-                item.attributeValues.values.firstOrNull { it.trackedEntityAttribute() == middleNameAttrUid }
-                    ?.value()
+        val middleNameValue =
+            item.allAttributeValues.values.firstOrNull { it.trackedEntityAttribute() == middleNameAttrUid }
+                ?.value()
 
-            val lastNameValue =
-                item.attributeValues.values.firstOrNull { it.trackedEntityAttribute() == lastNameAttrUid }
-                    ?.value()
+        val lastNameValue =
+            item.allAttributeValues.values.firstOrNull { it.trackedEntityAttribute() == lastNameAttrUid }
+                ?.value()
 
-            "$firsNameValue $middleNameValue $lastNameValue"
-        }
+        return listOfNotNull(firsNameValue, middleNameValue, lastNameValue)
+            .filter { it != "-" } // DHIS2 D2 empty attribute default value
+            .filter { it.isNotBlank() }
+            .joinToString(separator = " ") { it.trim() }
+            .takeIf { it.isNotBlank() } ?: "-"
     }
 
     private fun getConfirmationDialogSubtitle(item: SearchTeiModel): String {

--- a/app/src/test/java/org/dhis2/usescases/searchTrackEntity/ui/mapper/TEICardMapperTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/searchTrackEntity/ui/mapper/TEICardMapperTest.kt
@@ -1,11 +1,15 @@
 package org.dhis2.usescases.searchTrackEntity.ui.mapper
 
 import android.content.Context
+import android.content.SharedPreferences
 import org.dhis2.R
 import org.dhis2.commons.data.SearchTeiModel
 import org.dhis2.commons.date.toDateSpan
 import org.dhis2.commons.date.toOverdueOrScheduledUiText
 import org.dhis2.commons.resources.ResourceManager
+import org.dhis2.usescases.teiDashboard.ui.mapper.firstNameAttrUid
+import org.dhis2.usescases.teiDashboard.ui.mapper.lastNameAttrUid
+import org.dhis2.usescases.teiDashboard.ui.mapper.middleNameAttrUid
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.enrollment.Enrollment
 import org.hisp.dhis.android.core.enrollment.EnrollmentStatus
@@ -17,14 +21,17 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.util.Date
+import org.dhis2.commons.biometrics.BiometricsPreference
 
 class TEICardMapperTest {
 
     private val context: Context = mock()
     private val resourceManager: ResourceManager = mock()
+    private val sharedPreferences: SharedPreferences = mock()
     private val currentDate = Date()
 
     private lateinit var mapper: TEICardMapper
@@ -43,6 +50,8 @@ class TEICardMapperTest {
             resourceManager.getString(R.string.overdue_today),
         ) doReturn "Today"
         whenever(resourceManager.getString(R.string.marked_follow_up)) doReturn "Marked for follow-up"
+        whenever(context.getSharedPreferences(eq("BASIC_SHARE_PREFS"), eq(Context.MODE_PRIVATE))) doReturn sharedPreferences
+        whenever(sharedPreferences.getString(eq(BiometricsPreference.BIOMETRICS_MODE), any())) doReturn "full"
 
         mapper = TEICardMapper(context, resourceManager)
     }
@@ -81,6 +90,79 @@ class TEICardMapperTest {
         )
     }
 
+    @Test
+    fun `should format confirmation dialog title correctly`() {
+        val attributeValues = linkedMapOf(
+            "First name" to createAttributeValue(firstNameAttrUid, "John"),
+            "Middle name" to createAttributeValue(middleNameAttrUid, "Peter"),
+            "Last name" to createAttributeValue(lastNameAttrUid, "Smith")
+        )
+
+        val model = SearchTeiModel().apply {
+            setAttributeValues(attributeValues)
+            attributeValues.forEach { (key, value) -> addToAllAttributes(key, value) }
+            tei = TrackedEntityInstance.builder()
+                .uid("TEIUid")
+                .lastUpdated(currentDate)
+                .aggregatedSyncState(State.SYNCED)
+                .build()
+        }
+
+        val result = mapper.mapForConfirmationDialog(model)
+        assertEquals("John Peter Smith", result.title)
+    }
+
+    @Test
+    fun `should handle empty values in confirmation dialog title`() {
+        val attributeValues = linkedMapOf(
+            "First name" to createAttributeValue(firstNameAttrUid, "John"),
+            "Middle name" to createAttributeValue(middleNameAttrUid, "-"),
+            "Last name" to createAttributeValue(lastNameAttrUid, "Smith")
+        )
+
+        val model = SearchTeiModel().apply {
+            setAttributeValues(attributeValues)
+            attributeValues.forEach { (key, value) -> addToAllAttributes(key, value) }
+            tei = TrackedEntityInstance.builder()
+                .uid("TEIUid")
+                .lastUpdated(currentDate)
+                .aggregatedSyncState(State.SYNCED)
+                .build()
+        }
+
+        val result = mapper.mapForConfirmationDialog(model)
+        assertEquals("John Smith", result.title)
+    }
+
+    @Test
+    fun `should return dash when all name values are empty`() {
+        val attributeValues = linkedMapOf(
+            "First name" to createAttributeValue(firstNameAttrUid, "-"),
+            "Middle name" to createAttributeValue(middleNameAttrUid, "-"),
+            "Last name" to createAttributeValue(lastNameAttrUid, "-")
+        )
+
+        val model = SearchTeiModel().apply {
+            setAttributeValues(attributeValues)
+            attributeValues.forEach { (key, value) -> addToAllAttributes(key, value) }
+            tei = TrackedEntityInstance.builder()
+                .uid("TEIUid")
+                .lastUpdated(currentDate)
+                .aggregatedSyncState(State.SYNCED)
+                .build()
+        }
+
+        val result = mapper.mapForConfirmationDialog(model)
+        assertEquals("-", result.title)
+    }
+
+    private fun createAttributeValue(uid: String, value: String): TrackedEntityAttributeValue {
+        return TrackedEntityAttributeValue.builder()
+            .trackedEntityAttribute(uid)
+            .value(value)
+            .build()
+    }
+
     private fun createFakeModel(): SearchTeiModel {
         val attributeValues = LinkedHashMap<String, TrackedEntityAttributeValue>()
         attributeValues["Name"] = TrackedEntityAttributeValue.builder()
@@ -105,6 +187,7 @@ class TEICardMapperTest {
                     .build(),
             )
             setAttributeValues(attributeValues)
+            attributeValues.forEach { (key, value) -> addToAllAttributes(key, value) }
 
             addProgramInfo(
                 Program.builder()

--- a/app/src/test/java/org/dhis2/usescases/searchTrackEntity/ui/mapper/TEICardMapperTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/searchTrackEntity/ui/mapper/TEICardMapperTest.kt
@@ -3,10 +3,12 @@ package org.dhis2.usescases.searchTrackEntity.ui.mapper
 import android.content.Context
 import android.content.SharedPreferences
 import org.dhis2.R
+import org.dhis2.commons.biometrics.BiometricsPreference
 import org.dhis2.commons.data.SearchTeiModel
 import org.dhis2.commons.date.toDateSpan
 import org.dhis2.commons.date.toOverdueOrScheduledUiText
 import org.dhis2.commons.resources.ResourceManager
+import org.dhis2.commons.ui.model.ListCardUiModel
 import org.dhis2.usescases.teiDashboard.ui.mapper.firstNameAttrUid
 import org.dhis2.usescases.teiDashboard.ui.mapper.lastNameAttrUid
 import org.dhis2.usescases.teiDashboard.ui.mapper.middleNameAttrUid
@@ -25,7 +27,6 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.util.Date
-import org.dhis2.commons.biometrics.BiometricsPreference
 
 class TEICardMapperTest {
 
@@ -92,56 +93,56 @@ class TEICardMapperTest {
 
     @Test
     fun `should format confirmation dialog title correctly`() {
-        val attributeValues = linkedMapOf(
-            "First name" to createAttributeValue(firstNameAttrUid, "John"),
-            "Middle name" to createAttributeValue(middleNameAttrUid, "Peter"),
-            "Last name" to createAttributeValue(lastNameAttrUid, "Smith")
+        val attributeValues = createAttributeValuesMap(
+            firstName = "John",
+            middleName = "Peter",
+            lastName = "Smith",
         )
 
-        val model = SearchTeiModel().apply {
-            setAttributeValues(attributeValues)
-            attributeValues.forEach { (key, value) -> addToAllAttributes(key, value) }
-            tei = TrackedEntityInstance.builder()
-                .uid("TEIUid")
-                .lastUpdated(currentDate)
-                .aggregatedSyncState(State.SYNCED)
-                .build()
-        }
+        val result = createModelAndMapForConfirmation(attributeValues)
 
-        val result = mapper.mapForConfirmationDialog(model)
         assertEquals("John Peter Smith", result.title)
     }
 
     @Test
     fun `should handle empty values in confirmation dialog title`() {
-        val attributeValues = linkedMapOf(
-            "First name" to createAttributeValue(firstNameAttrUid, "John"),
-            "Middle name" to createAttributeValue(middleNameAttrUid, "-"),
-            "Last name" to createAttributeValue(lastNameAttrUid, "Smith")
+        val attributeValues = createAttributeValuesMap(
+            firstName = "John",
+            middleName = "-",
+            lastName = "Smith",
         )
 
-        val model = SearchTeiModel().apply {
-            setAttributeValues(attributeValues)
-            attributeValues.forEach { (key, value) -> addToAllAttributes(key, value) }
-            tei = TrackedEntityInstance.builder()
-                .uid("TEIUid")
-                .lastUpdated(currentDate)
-                .aggregatedSyncState(State.SYNCED)
-                .build()
-        }
+        val result = createModelAndMapForConfirmation(attributeValues)
 
-        val result = mapper.mapForConfirmationDialog(model)
         assertEquals("John Smith", result.title)
     }
 
     @Test
     fun `should return dash when all name values are empty`() {
-        val attributeValues = linkedMapOf(
-            "First name" to createAttributeValue(firstNameAttrUid, "-"),
-            "Middle name" to createAttributeValue(middleNameAttrUid, "-"),
-            "Last name" to createAttributeValue(lastNameAttrUid, "-")
+        val attributeValues = createAttributeValuesMap(
+            firstName = "-",
+            middleName = "-",
+            lastName = "-",
         )
 
+        val result = createModelAndMapForConfirmation(attributeValues)
+
+        assertEquals("-", result.title)
+    }
+
+    private fun createAttributeValuesMap(
+        firstName: String,
+        middleName: String,
+        lastName: String,
+    ): LinkedHashMap<String, TrackedEntityAttributeValue> = linkedMapOf(
+        "First name" to createAttributeValue(firstNameAttrUid, firstName),
+        "Middle name" to createAttributeValue(middleNameAttrUid, middleName),
+        "Last name" to createAttributeValue(lastNameAttrUid, lastName)
+    )
+
+    private fun createModelAndMapForConfirmation(
+        attributeValues: LinkedHashMap<String, TrackedEntityAttributeValue>,
+    ): ListCardUiModel {
         val model = SearchTeiModel().apply {
             setAttributeValues(attributeValues)
             attributeValues.forEach { (key, value) -> addToAllAttributes(key, value) }
@@ -151,9 +152,7 @@ class TEICardMapperTest {
                 .aggregatedSyncState(State.SYNCED)
                 .build()
         }
-
-        val result = mapper.mapForConfirmationDialog(model)
-        assertEquals("-", result.title)
+        return mapper.mapForConfirmationDialog(model)
     }
 
     private fun createAttributeValue(uid: String, value: String): TrackedEntityAttributeValue {


### PR DESCRIPTION
What has changed:

* When the parts of the TEI full name were pulled from `attributeValues`, some could end up being filtered out (depending to the Program config) and missing in the biometric search result confirmation dialog title. Pulling them from `allAttributeValues` directly instead.
* Empty name parts handling improved, tests for that added.
* Missing mocks added in the test.