### PR TITLE
Sequential search result list viewing from beginning

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/listView/SearchTEList.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/listView/SearchTEList.kt
@@ -307,6 +307,14 @@ class SearchTEList : FragmentGlobalAbstract() {
                 displayResult(null)
             }
         }
+
+        scrollToTopOnSequentialSearch()
+    }
+
+    private fun scrollToTopOnSequentialSearch() {
+        viewModel.sequentialSearch.observe(viewLifecycleOwner) {
+            recycler.scrollToPosition(0)
+        }
     }
 
     private fun updateRecycler() {
@@ -335,15 +343,8 @@ class SearchTEList : FragmentGlobalAbstract() {
         displayResult(null)
     }
 
-    private var previousSequentialSearch: SequentialSearch? = null
-
     private fun initData() {
         displayLoadingData()
-
-        if (viewModel.sequentialSearch.value != previousSequentialSearch) {
-            recycler.scrollToPosition(0)
-        }
-        previousSequentialSearch = viewModel.sequentialSearch.value
 
         viewModel.fetchListResults {
 

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/listView/SearchTEList.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/listView/SearchTEList.kt
@@ -335,8 +335,15 @@ class SearchTEList : FragmentGlobalAbstract() {
         displayResult(null)
     }
 
+    private var previousSequentialSearch: SequentialSearch? = null
+
     private fun initData() {
         displayLoadingData()
+
+        if (viewModel.sequentialSearch.value != previousSequentialSearch) {
+            recycler.scrollToPosition(0)
+        }
+        previousSequentialSearch = viewModel.sequentialSearch.value
 
         viewModel.fetchListResults {
 


### PR DESCRIPTION
Behavior before:

* In Programs with sequential search (with biometrics enabled), search results could appear pre-scrolled down from the beginning of the list, depending on list contents and scroll position before search.

Behavior after:

* Search results are shown from the beginning for every stage of sequential search.