### PR TITLE
TEI Relationship sync failure fix

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/relationships/RelationshipPresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/relationships/RelationshipPresenter.kt
@@ -115,52 +115,30 @@ class RelationshipPresenter internal constructor(
     }
 
     fun addRelationship(selectedTei: String, relationshipTypeUid: String) {
-        if (teiUid != null) {
-            addTeiToTeiRelationship(teiUid, selectedTei, relationshipTypeUid)
-        } else if (eventUid != null) {
-            addEventToTeiRelationship(eventUid, selectedTei, relationshipTypeUid)
-        }
-    }
-
-    private fun addTeiToTeiRelationship(
-        teiUid: String,
-        selectedTei: String,
-        relationshipTypeUid: String,
-    ) {
         try {
-            val relationship =
-                RelationshipHelper.teiToTeiRelationship(teiUid, selectedTei, relationshipTypeUid)
-            d2.relationshipModule().relationships().blockingAdd(relationship)
-        } catch (e: D2Error) {
-            view.displayMessage(e.errorDescription())
-        } finally {
-            updateRelationships.onNext(true)
-        }
-    }
-
-    private fun addEventToTeiRelationship(
-        eventUid: String,
-        selectedTei: String,
-        relationshipTypeUid: String,
-    ) {
-        try {
-            val relationship =
+            val relationship = if (teiUid != null) {
+                RelationshipHelper.teiToTeiRelationship(selectedTei, teiUid, relationshipTypeUid)
+            } else if (eventUid != null) {
                 RelationshipHelper.eventToTeiRelationship(
-                    eventUid,
                     selectedTei,
-                    relationshipTypeUid,
+                    eventUid,
+                    relationshipTypeUid
                 )
-            d2.relationshipModule().relationships().blockingAdd(relationship)
+            } else {
+                null
+            }
+            relationship?.let {
+                d2.relationshipModule().relationships().blockingAdd(it)
+                updateRelationships.onNext(true)
+            }
         } catch (e: D2Error) {
             view.displayMessage(e.errorDescription())
-        } finally {
-            updateRelationships.onNext(true)
         }
     }
 
     fun openDashboard(teiUid: String) {
         if (d2.trackedEntityModule()
-                .trackedEntityInstances().uid(teiUid).blockingGet()!!.state() !=
+                .trackedEntityInstances().uid(teiUid).blockingGet()?.aggregatedSyncState() !=
             State.RELATIONSHIP
         ) {
             if (d2.enrollmentModule().enrollments()

--- a/app/src/test/java/org/dhis2/usescases/teiDashboard/dashboardfragments/relationships/RelationshipPresenterTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/teiDashboard/dashboardfragments/relationships/RelationshipPresenterTest.kt
@@ -233,7 +233,7 @@ class RelationshipPresenterTest {
     private fun getMockedTei(state: State): TrackedEntityInstance {
         return TrackedEntityInstance.builder()
             .uid("teiUid")
-            .state(state)
+            .aggregatedSyncState(state)
             .build()
     }
 


### PR DESCRIPTION
### What was wrong

After adding records in two different Programs configured for supporting a Relationship, and after creating the Relationship between the records, an attempt to sync the linked records results in a still non-synced state. Without an explicit error given. In the DHIS2 instance web UI, the Relationship doesn't appear.

#### Other reports on this issue:

* https://community.dhis2.org/t/cannot-see-tei-relationship-created-on-dhis2-tracker-mobile-app-on-tracker-capture-web/45904
* https://community.dhis2.org/t/tei-relationships-captured-from-dhis2-android-not-reflecting-on-web-app/62614

### How it should work

The records linked by the newly added Relationship do complete sync, and after that the Relationship can be seen in the DHIS2 instance web UI.

### Which DHIS2 app versions have the bug

* This repo's `develop-simprints` branch before this pull request
* The upstream DHIS2 app current release 3.1.0.1 on https://play.google.com/store/apps/details?id=com.dhis2

### Which DHIS2 app versions are fixed

* The upsteam DHIS2 app `develop` branch since the fix at https://github.com/dhis2/dhis2-android-capture-app/pull/3928 (Jira: https://dhis2.atlassian.net/browse/ANDROAPP-6535) was merged

### Solution

Given that the upstream DHIS2 app is quite ahead, and quite different from this `develop-simprints` branch, a subset of the ANDROAPP-6535 fix has been backported in this pull request, this should fix the issue.