### PR TITLE
[WIDP] Avoid launch the same notification twice

### DIFF
--- a/app/src/main/java/org/dhis2/App.java
+++ b/app/src/main/java/org/dhis2/App.java
@@ -46,6 +46,7 @@ import org.dhis2.maps.MapController;
 import org.dhis2.usescases.crash.CrashActivity;
 import org.dhis2.usescases.login.LoginComponent;
 import org.dhis2.usescases.login.LoginModule;
+import org.dhis2.usescases.notifications.di.NotificationsModule;
 import org.dhis2.usescases.teiDashboard.TeiDashboardComponent;
 import org.dhis2.usescases.teiDashboard.TeiDashboardModule;
 import org.dhis2.utils.analytics.AnalyticsModule;
@@ -209,7 +210,8 @@ public class App extends MultiDexApplication implements Components, LifecycleObs
                 .coroutineDispatchers(new DispatcherModule())
                 .crashReportModule(new CrashReportModule())
                 .customDispatcher(new CustomDispatcherModule())
-                .featureConfigModule(new FeatureConfigModule());
+                .featureConfigModule(new FeatureConfigModule())
+                .notificationsModule(new NotificationsModule());
     }
 
     @NonNull

--- a/app/src/main/java/org/dhis2/AppComponent.java
+++ b/app/src/main/java/org/dhis2/AppComponent.java
@@ -16,6 +16,7 @@ import org.dhis2.data.service.workManager.WorkManagerController;
 import org.dhis2.data.service.workManager.WorkManagerModule;
 import org.dhis2.usescases.login.LoginComponent;
 import org.dhis2.usescases.login.LoginModule;
+import org.dhis2.usescases.notifications.di.NotificationsModule;
 import org.dhis2.usescases.splash.SplashComponent;
 import org.dhis2.usescases.splash.SplashModule;
 import org.dhis2.utils.Validator;
@@ -51,7 +52,8 @@ import dispatch.core.DispatcherProvider;
         DispatcherModule.class,
         FeatureConfigModule.class,
         NetworkUtilsModule.class,
-        CustomDispatcherModule.class
+        CustomDispatcherModule.class,
+        NotificationsModule.class
 })
 public  interface AppComponent {
 
@@ -76,6 +78,8 @@ public  interface AppComponent {
         Builder networkUtilsModule(NetworkUtilsModule networkUtilsModule);
 
         Builder customDispatcher(CustomDispatcherModule dispatcherProvider);
+
+        Builder notificationsModule(NotificationsModule notificationsModule);
 
         AppComponent build();
     }

--- a/app/src/main/java/org/dhis2/data/service/SyncDataWorkerModule.kt
+++ b/app/src/main/java/org/dhis2/data/service/SyncDataWorkerModule.kt
@@ -23,19 +23,6 @@ class SyncDataWorkerModule {
 
     @Provides
     @PerService
-    fun notificationsRepository(
-        d2: D2,
-        preference: BasicPreferenceProvider
-    ): NotificationRepository {
-        val notificationsApi = d2.retrofit().create(
-            NotificationsApi::class.java
-        )
-        val userGroupsApi = d2.retrofit().create(UserGroupsApi::class.java)
-        return NotificationD2Repository(d2, preference, notificationsApi, userGroupsApi)
-    }
-
-    @Provides
-    @PerService
     internal fun syncPresenter(
         d2: D2,
         preferences: PreferenceProvider,

--- a/app/src/main/java/org/dhis2/data/service/SyncGranularRxModule.kt
+++ b/app/src/main/java/org/dhis2/data/service/SyncGranularRxModule.kt
@@ -3,11 +3,7 @@ package org.dhis2.data.service
 import dagger.Module
 import dagger.Provides
 import org.dhis2.commons.di.dagger.PerService
-import org.dhis2.commons.prefs.BasicPreferenceProvider
 import org.dhis2.commons.prefs.PreferenceProvider
-import org.dhis2.data.notifications.NotificationD2Repository
-import org.dhis2.data.notifications.NotificationsApi
-import org.dhis2.data.notifications.UserGroupsApi
 import org.dhis2.data.service.workManager.WorkManagerController
 import org.dhis2.usescases.notifications.domain.NotificationRepository
 import org.dhis2.utils.analytics.AnalyticsHelper
@@ -19,19 +15,6 @@ class SyncGranularRxModule {
     @PerService
     fun syncRepository(d2: D2): SyncRepository {
         return SyncRepositoryImpl(d2)
-    }
-
-    @Provides
-    @PerService
-    fun notificationsRepository(
-        d2: D2,
-        preference: BasicPreferenceProvider
-    ): NotificationRepository {
-        val notificationsApi = d2.retrofit().create(
-            NotificationsApi::class.java
-        )
-        val userGroupsApi = d2.retrofit().create(UserGroupsApi::class.java)
-        return NotificationD2Repository(d2, preference, notificationsApi, userGroupsApi)
     }
 
     @Provides

--- a/app/src/main/java/org/dhis2/data/service/SyncInitWorkerModule.kt
+++ b/app/src/main/java/org/dhis2/data/service/SyncInitWorkerModule.kt
@@ -3,11 +3,7 @@ package org.dhis2.data.service
 import dagger.Module
 import dagger.Provides
 import org.dhis2.commons.di.dagger.PerService
-import org.dhis2.commons.prefs.BasicPreferenceProvider
 import org.dhis2.commons.prefs.PreferenceProvider
-import org.dhis2.data.notifications.NotificationD2Repository
-import org.dhis2.data.notifications.NotificationsApi
-import org.dhis2.data.notifications.UserGroupsApi
 import org.dhis2.data.service.workManager.WorkManagerController
 import org.dhis2.usescases.notifications.domain.NotificationRepository
 import org.dhis2.utils.analytics.AnalyticsHelper
@@ -19,19 +15,6 @@ class SyncInitWorkerModule {
     @PerService
     fun syncRepository(d2: D2): SyncRepository {
         return SyncRepositoryImpl(d2)
-    }
-
-    @Provides
-    @PerService
-    fun notificationsRepository(
-        d2: D2,
-        preference: BasicPreferenceProvider
-    ): NotificationRepository {
-        val notificationsApi = d2.retrofit().create(
-            NotificationsApi::class.java
-        )
-        val userGroupsApi = d2.retrofit().create(UserGroupsApi::class.java)
-        return NotificationD2Repository(d2, preference, notificationsApi, userGroupsApi)
     }
 
     @Provides

--- a/app/src/main/java/org/dhis2/data/service/SyncMetadataWorkerModule.kt
+++ b/app/src/main/java/org/dhis2/data/service/SyncMetadataWorkerModule.kt
@@ -3,11 +3,7 @@ package org.dhis2.data.service
 import dagger.Module
 import dagger.Provides
 import org.dhis2.commons.di.dagger.PerService
-import org.dhis2.commons.prefs.BasicPreferenceProvider
 import org.dhis2.commons.prefs.PreferenceProvider
-import org.dhis2.data.notifications.NotificationD2Repository
-import org.dhis2.data.notifications.NotificationsApi
-import org.dhis2.data.notifications.UserGroupsApi
 import org.dhis2.data.service.workManager.WorkManagerController
 import org.dhis2.usescases.notifications.domain.NotificationRepository
 import org.dhis2.utils.analytics.AnalyticsHelper
@@ -19,19 +15,6 @@ class SyncMetadataWorkerModule {
     @PerService
     fun syncRepository(d2: D2): SyncRepository {
         return SyncRepositoryImpl(d2)
-    }
-
-    @Provides
-    @PerService
-    fun notificationsRepository(
-        d2: D2,
-        preference: BasicPreferenceProvider
-    ): NotificationRepository {
-        val notificationsApi = d2.retrofit().create(
-            NotificationsApi::class.java
-        )
-        val userGroupsApi = d2.retrofit().create(UserGroupsApi::class.java)
-        return NotificationD2Repository(d2, preference, notificationsApi, userGroupsApi)
     }
 
     @Provides

--- a/app/src/main/java/org/dhis2/usescases/main/MainActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/main/MainActivity.kt
@@ -65,17 +65,13 @@ const val AVOID_SYNC = "AvoidSync"
 class MainActivity :
     ActivityGlobalAbstract(),
     MainView,
-    DrawerLayout.DrawerListener,
-    NotificationsView {
+    DrawerLayout.DrawerListener {
 
     private lateinit var binding: ActivityMainBinding
     lateinit var mainComponent: MainComponent
 
     @Inject
     lateinit var presenter: MainPresenter
-
-    @Inject
-    lateinit var notificationsPresenter: NotificationsPresenter
 
     @Inject
     lateinit var newAdapter: FiltersAdapter
@@ -228,9 +224,12 @@ class MainActivity :
         if (!presenter.wasSyncAlreadyDone()) {
             presenter.launchInitialDataSync()
         } else if (!singleProgramNavigationDone && presenter.hasOneHomeItem()) {
+            notificationsPresenter.markShowNotificationsAsPending()
+
             navigateToSingleProgram()
         } else {
-            notificationsPresenter.refresh()
+            notificationsPresenter.markShowNotificationsAsPending()
+            notificationsPresenter.refresh(this)
         }
 
         checkNotificationPermission()
@@ -704,23 +703,5 @@ class MainActivity :
     private fun launchUrl(uri: Uri) {
         val intent = Intent(Intent.ACTION_VIEW, uri)
         startActivity(intent)
-    }
-
-    override fun renderNotifications(notifications: List<Notification>) {
-        notifications.forEach(::showNotification)
-    }
-
-    private fun showNotification(notification: Notification) {
-        val markwon = Markwon.create(this)
-        val content = markwon.toMarkdown(notification.content)
-
-        android.app.AlertDialog.Builder(context, R.style.CustomDialog)
-            .setTitle("Notification")
-            .setMessage(content)
-            .setPositiveButton(getString(R.string.wipe_data_ok)) { dialog, _ ->
-                notificationsPresenter.markNotificationAsRead(notification)
-            }
-            .setCancelable(true)
-            .show()
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/main/MainModule.kt
+++ b/app/src/main/java/org/dhis2/usescases/main/MainModule.kt
@@ -9,20 +9,31 @@ import org.dhis2.commons.filters.FilterManager
 import org.dhis2.commons.filters.FiltersAdapter
 import org.dhis2.commons.filters.data.FilterRepository
 import org.dhis2.commons.matomo.MatomoAnalyticsController
+import org.dhis2.commons.prefs.BasicPreferenceProvider
 import org.dhis2.commons.prefs.PreferenceProvider
 import org.dhis2.commons.schedulers.SchedulerProvider
 import org.dhis2.commons.viewmodel.DispatcherProvider
+import org.dhis2.data.notifications.NotificationD2Repository
+import org.dhis2.data.notifications.NotificationsApi
+import org.dhis2.data.notifications.UserD2Repository
+import org.dhis2.data.notifications.UserGroupsApi
 import org.dhis2.data.server.UserManager
 import org.dhis2.data.service.SyncStatusController
 import org.dhis2.data.service.VersionRepository
 import org.dhis2.data.service.workManager.WorkManagerController
 import org.dhis2.usescases.login.SyncIsPerformedInteractor
+import org.dhis2.usescases.notifications.domain.GetNotifications
+import org.dhis2.usescases.notifications.domain.MarkNotificationAsRead
+import org.dhis2.usescases.notifications.domain.NotificationRepository
+import org.dhis2.usescases.notifications.domain.UserRepository
+import org.dhis2.usescases.notifications.presentation.NotificationsPresenter
+import org.dhis2.usescases.notifications.presentation.NotificationsView
 import org.dhis2.usescases.settings.DeleteUserData
 import org.dhis2.utils.customviews.navigationbar.NavigationPageConfigurator
 import org.hisp.dhis.android.core.D2
 
 @Module
-class MainModule(val view: MainView) {
+class MainModule(val view: MainView, private val notificationsView: NotificationsView) {
 
     @Provides
     @PerActivity
@@ -97,6 +108,68 @@ class MainModule(val view: MainView) {
             workManagerController,
             FilterManager.getInstance(),
             preferencesProvider,
+        )
+    }
+
+    @Provides
+    @PerActivity
+    internal fun notificationsPresenter(
+        getNotifications: GetNotifications,
+        markNotificationAsRead: MarkNotificationAsRead
+    ): NotificationsPresenter {
+        return NotificationsPresenter(
+            notificationsView,
+            getNotifications,
+            markNotificationAsRead
+        )
+    }
+
+    @Provides
+    @PerActivity
+    internal fun getMarkNotificationAsRead(
+        notificationRepository: NotificationRepository,
+        userRepository: UserRepository
+    ): MarkNotificationAsRead {
+        return MarkNotificationAsRead(notificationRepository, userRepository)
+    }
+
+    @Provides
+    @PerActivity
+    internal fun getNotifications(
+        notificationRepository: NotificationRepository,
+    ): GetNotifications {
+        return GetNotifications(notificationRepository)
+    }
+
+    @Provides
+    @PerActivity
+    internal fun notificationsRepository(
+        d2: D2,
+        preferences: BasicPreferenceProvider
+    ): NotificationRepository {
+        val biometricsConfigApi = d2.retrofit().create(
+            NotificationsApi::class.java
+        )
+
+        val userGroupsApi = d2.retrofit().create(
+            UserGroupsApi::class.java
+        )
+
+        return NotificationD2Repository(
+            d2,
+            preferences,
+            biometricsConfigApi,
+            userGroupsApi
+        )
+    }
+
+    @Provides
+    @PerActivity
+    internal fun userRepository(
+        d2: D2,
+    ): UserRepository {
+        return UserD2Repository(
+            d2
         )
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/main/MainModule.kt
+++ b/app/src/main/java/org/dhis2/usescases/main/MainModule.kt
@@ -9,24 +9,14 @@ import org.dhis2.commons.filters.FilterManager
 import org.dhis2.commons.filters.FiltersAdapter
 import org.dhis2.commons.filters.data.FilterRepository
 import org.dhis2.commons.matomo.MatomoAnalyticsController
-import org.dhis2.commons.prefs.BasicPreferenceProvider
 import org.dhis2.commons.prefs.PreferenceProvider
 import org.dhis2.commons.schedulers.SchedulerProvider
 import org.dhis2.commons.viewmodel.DispatcherProvider
-import org.dhis2.data.notifications.NotificationD2Repository
-import org.dhis2.data.notifications.NotificationsApi
-import org.dhis2.data.notifications.UserD2Repository
-import org.dhis2.data.notifications.UserGroupsApi
 import org.dhis2.data.server.UserManager
 import org.dhis2.data.service.SyncStatusController
 import org.dhis2.data.service.VersionRepository
 import org.dhis2.data.service.workManager.WorkManagerController
 import org.dhis2.usescases.login.SyncIsPerformedInteractor
-import org.dhis2.usescases.notifications.domain.GetNotifications
-import org.dhis2.usescases.notifications.domain.MarkNotificationAsRead
-import org.dhis2.usescases.notifications.domain.NotificationRepository
-import org.dhis2.usescases.notifications.domain.UserRepository
-import org.dhis2.usescases.notifications.presentation.NotificationsPresenter
 import org.dhis2.usescases.notifications.presentation.NotificationsView
 import org.dhis2.usescases.settings.DeleteUserData
 import org.dhis2.utils.customviews.navigationbar.NavigationPageConfigurator
@@ -108,68 +98,6 @@ class MainModule(val view: MainView, private val notificationsView: Notification
             workManagerController,
             FilterManager.getInstance(),
             preferencesProvider,
-        )
-    }
-
-    @Provides
-    @PerActivity
-    internal fun notificationsPresenter(
-        getNotifications: GetNotifications,
-        markNotificationAsRead: MarkNotificationAsRead
-    ): NotificationsPresenter {
-        return NotificationsPresenter(
-            notificationsView,
-            getNotifications,
-            markNotificationAsRead
-        )
-    }
-
-    @Provides
-    @PerActivity
-    internal fun getMarkNotificationAsRead(
-        notificationRepository: NotificationRepository,
-        userRepository: UserRepository
-    ): MarkNotificationAsRead {
-        return MarkNotificationAsRead(notificationRepository, userRepository)
-    }
-
-    @Provides
-    @PerActivity
-    internal fun getNotifications(
-        notificationRepository: NotificationRepository,
-    ): GetNotifications {
-        return GetNotifications(notificationRepository)
-    }
-
-    @Provides
-    @PerActivity
-    internal fun notificationsRepository(
-        d2: D2,
-        preferences: BasicPreferenceProvider
-    ): NotificationRepository {
-        val biometricsConfigApi = d2.retrofit().create(
-            NotificationsApi::class.java
-        )
-
-        val userGroupsApi = d2.retrofit().create(
-            UserGroupsApi::class.java
-        )
-
-        return NotificationD2Repository(
-            d2,
-            preferences,
-            biometricsConfigApi,
-            userGroupsApi
-        )
-    }
-
-    @Provides
-    @PerActivity
-    internal fun userRepository(
-        d2: D2,
-    ): UserRepository {
-        return UserD2Repository(
-            d2
         )
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/main/program/ProgramFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/main/program/ProgramFragment.kt
@@ -1,6 +1,5 @@
 package org.dhis2.usescases.main.program
 
-import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
 import android.graphics.drawable.GradientDrawable
@@ -18,7 +17,6 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.view.ViewCompat
 import androidx.databinding.DataBindingUtil
 import com.google.android.material.snackbar.Snackbar
-import io.noties.markwon.Markwon
 import org.dhis2.App
 import org.dhis2.R
 import org.dhis2.android.rtsm.commons.Constants.INTENT_EXTRA_APP_CONFIG
@@ -34,11 +32,6 @@ import org.dhis2.commons.sync.SyncContext
 import org.dhis2.databinding.FragmentProgramBinding
 import org.dhis2.usescases.general.FragmentGlobalAbstract
 import org.dhis2.usescases.main.MainActivity
-import org.dhis2.usescases.notifications.domain.Notification
-import org.dhis2.usescases.notifications.presentation.NotificationsPresenter
-import org.dhis2.usescases.notifications.presentation.NotificationsView
-import org.dhis2.usescases.programEventDetail.ProgramEventDetailActivity
-import org.dhis2.usescases.searchTrackEntity.SearchTEActivity
 import org.dhis2.usescases.main.navigateTo
 import org.dhis2.usescases.main.toHomeItemData
 import org.dhis2.utils.HelpManager
@@ -48,16 +41,12 @@ import org.dhis2.utils.granularsync.SyncStatusDialog
 import timber.log.Timber
 import javax.inject.Inject
 
-class ProgramFragment : FragmentGlobalAbstract(), ProgramView,
-    NotificationsView {
+class ProgramFragment : FragmentGlobalAbstract(), ProgramView{
 
     private lateinit var binding: FragmentProgramBinding
 
     @Inject
     lateinit var presenter: ProgramPresenter
-
-    @Inject
-    lateinit var notificationsPresenter: NotificationsPresenter
 
     @Inject
     lateinit var animation: ProgramAnimation
@@ -72,7 +61,7 @@ class ProgramFragment : FragmentGlobalAbstract(), ProgramView,
     override fun onAttach(context: Context) {
         super.onAttach(context)
         activity?.let {
-            (it.applicationContext as App).userComponent()?.plus(ProgramModule(this, this))?.inject(this)
+            (it.applicationContext as App).userComponent()?.plus(ProgramModule(this))?.inject(this)
         }
     }
 
@@ -124,8 +113,6 @@ class ProgramFragment : FragmentGlobalAbstract(), ProgramView,
         animation.initBackdropCorners(
             binding.drawerLayout.background.mutate() as GradientDrawable,
         )
-
-        notificationsPresenter.refresh()
     }
 
     override fun onPause() {
@@ -250,23 +237,5 @@ class ProgramFragment : FragmentGlobalAbstract(), ProgramView,
 
     companion object {
         const val FRAGMENT_TAG = "SYNC"
-    }
-
-    override fun renderNotifications(notifications: List<Notification>) {
-        notifications.forEach(::showNotification)
-    }
-
-    private fun showNotification(notification: Notification) {
-        val markwon = Markwon.create(requireActivity())
-        val content = markwon.toMarkdown(notification.content)
-
-        AlertDialog.Builder(context, R.style.CustomDialog)
-            .setTitle("Notification")
-            .setMessage(content)
-            .setPositiveButton(getString(R.string.wipe_data_ok)) { dialog, _ ->
-                notificationsPresenter.markNotificationAsRead(notification)
-            }
-            .setCancelable(true)
-            .show()
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/main/program/ProgramModule.kt
+++ b/app/src/main/java/org/dhis2/usescases/main/program/ProgramModule.kt
@@ -6,30 +6,18 @@ import org.dhis2.commons.di.dagger.PerFragment
 import org.dhis2.commons.filters.FilterManager
 import org.dhis2.commons.filters.data.FilterPresenter
 import org.dhis2.commons.matomo.MatomoAnalyticsController
-import org.dhis2.commons.prefs.BasicPreferenceProvider
 import org.dhis2.commons.resources.ColorUtils
 import org.dhis2.commons.resources.MetadataIconProvider
 import org.dhis2.commons.resources.ResourceManager
 import org.dhis2.commons.schedulers.SchedulerProvider
 import org.dhis2.data.dhislogic.DhisProgramUtils
 import org.dhis2.data.dhislogic.DhisTrackedEntityInstanceUtils
-import org.dhis2.data.notifications.NotificationD2Repository
-import org.dhis2.data.notifications.NotificationsApi
-import org.dhis2.data.notifications.UserD2Repository
-import org.dhis2.data.notifications.UserGroupsApi
 import org.dhis2.data.service.SyncStatusController
-import org.dhis2.usescases.notifications.domain.GetNotifications
-import org.dhis2.usescases.notifications.domain.MarkNotificationAsRead
-import org.dhis2.usescases.notifications.domain.NotificationRepository
-import org.dhis2.usescases.notifications.domain.UserRepository
-import org.dhis2.usescases.notifications.presentation.NotificationsPresenter
-import org.dhis2.usescases.notifications.presentation.NotificationsView
 import org.hisp.dhis.android.core.D2
 
 @Module
 class ProgramModule(
-    private val view: ProgramView,
-    private val notificationsView: NotificationsView
+    private val view: ProgramView
 ) {
 
     @Provides
@@ -77,67 +65,5 @@ class ProgramModule(
     @PerFragment
     fun provideAnimations(): ProgramAnimation {
         return ProgramAnimation()
-    }
-
-    @Provides
-    @PerFragment
-    internal fun notificationsPresenter(
-        getNotifications: GetNotifications,
-        markNotificationAsRead: MarkNotificationAsRead
-    ): NotificationsPresenter {
-        return NotificationsPresenter(
-            notificationsView,
-            getNotifications,
-            markNotificationAsRead
-        )
-    }
-
-    @Provides
-    @PerFragment
-    internal fun getMarkNotificationAsRead(
-        notificationRepository: NotificationRepository,
-        userRepository: UserRepository
-    ): MarkNotificationAsRead {
-        return MarkNotificationAsRead(notificationRepository, userRepository)
-    }
-
-    @Provides
-    @PerFragment
-    internal fun getNotifications(
-        notificationRepository: NotificationRepository,
-    ): GetNotifications {
-        return GetNotifications(notificationRepository)
-    }
-
-    @Provides
-    @PerFragment
-    internal fun notificationsRepository(
-        d2: D2,
-        preferences: BasicPreferenceProvider
-    ): NotificationRepository {
-        val biometricsConfigApi = d2.retrofit().create(
-            NotificationsApi::class.java
-        )
-
-        val userGroupsApi = d2.retrofit().create(
-            UserGroupsApi::class.java
-        )
-
-        return NotificationD2Repository(
-            d2,
-            preferences,
-            biometricsConfigApi,
-            userGroupsApi
-        )
-    }
-
-    @Provides
-    @PerFragment
-    internal fun userRepository(
-        d2: D2,
-    ): UserRepository {
-        return UserD2Repository(
-            d2
-        )
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/notifications/di/NotificationsComponent.kt
+++ b/app/src/main/java/org/dhis2/usescases/notifications/di/NotificationsComponent.kt
@@ -1,0 +1,12 @@
+/*
+package org.dhis2.usescases.notifications.di
+
+import dagger.Subcomponent
+import org.dhis2.commons.di.dagger.PerActivity
+
+@PerActivity
+@Subcomponent(modules = [NotificationsModule::class])
+interface NotificationsComponent {
+    fun inject()
+}
+*/

--- a/app/src/main/java/org/dhis2/usescases/notifications/di/NotificationsModule.kt
+++ b/app/src/main/java/org/dhis2/usescases/notifications/di/NotificationsModule.kt
@@ -1,0 +1,81 @@
+package org.dhis2.usescases.notifications.di
+
+import dagger.Module
+import dagger.Provides
+import org.dhis2.commons.prefs.BasicPreferenceProvider
+import org.dhis2.data.notifications.NotificationD2Repository
+import org.dhis2.data.notifications.NotificationsApi
+import org.dhis2.data.notifications.UserD2Repository
+import org.dhis2.data.notifications.UserGroupsApi
+import org.dhis2.usescases.notifications.domain.GetNotifications
+import org.dhis2.usescases.notifications.domain.MarkNotificationAsRead
+import org.dhis2.usescases.notifications.domain.NotificationRepository
+import org.dhis2.usescases.notifications.domain.UserRepository
+import org.dhis2.usescases.notifications.presentation.NotificationsPresenter
+import org.hisp.dhis.android.core.D2Manager
+import javax.inject.Singleton
+
+@Module
+class NotificationsModule () {
+    @Provides
+    @Singleton
+    internal fun notificationsPresenter(
+        getNotifications: GetNotifications,
+        markNotificationAsRead: MarkNotificationAsRead
+    ): NotificationsPresenter {
+        return NotificationsPresenter(
+            getNotifications,
+            markNotificationAsRead
+        )
+    }
+
+    @Provides
+    @Singleton
+    internal fun getMarkNotificationAsRead(
+        notificationRepository: NotificationRepository,
+        userRepository: UserRepository
+    ): MarkNotificationAsRead {
+        return MarkNotificationAsRead(notificationRepository, userRepository)
+    }
+
+    @Provides
+    @Singleton
+    internal fun getNotifications(
+        notificationRepository: NotificationRepository,
+    ): GetNotifications {
+        return GetNotifications(notificationRepository)
+    }
+
+    @Provides
+    @Singleton
+    internal fun notificationsRepository(
+        preferences: BasicPreferenceProvider
+    ): NotificationRepository {
+        val d2 = D2Manager.getD2()
+
+        val biometricsConfigApi = d2.retrofit().create(
+            NotificationsApi::class.java
+        )
+
+        val userGroupsApi = d2.retrofit().create(
+            UserGroupsApi::class.java
+        )
+
+        return NotificationD2Repository(
+            d2,
+            preferences,
+            biometricsConfigApi,
+            userGroupsApi
+        )
+    }
+
+    @Provides
+    @Singleton
+    internal fun userRepository(): UserRepository {
+        val d2 = D2Manager.getD2()
+
+        return UserD2Repository(
+            d2
+        )
+    }
+}

--- a/app/src/main/java/org/dhis2/usescases/notifications/presentation/NotificationsPresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/notifications/presentation/NotificationsPresenter.kt
@@ -8,14 +8,20 @@ import org.dhis2.usescases.notifications.domain.MarkNotificationAsRead
 import org.dhis2.usescases.notifications.domain.Notification
 
 class NotificationsPresenter(
-    private val notificationsView: NotificationsView,
     private val getNotifications: GetNotifications,
     private val markNotificationAsRead: MarkNotificationAsRead
 ){
-    fun refresh() {
-        val notifications = getNotifications()
+    fun refresh(notificationsView: NotificationsView) {
+        if (ShowNotifications.isPending) {
+            ShowNotifications.isPending = false
+            val notifications = getNotifications()
 
-        notificationsView.renderNotifications(notifications)
+            notificationsView.renderNotifications(notifications)
+        }
+    }
+
+    fun markShowNotificationsAsPending (){
+        ShowNotifications.isPending = true
     }
 
     fun markNotificationAsRead(notification: Notification) {
@@ -23,6 +29,10 @@ class NotificationsPresenter(
             markNotificationAsRead.invoke(notification.id)
         }
     }
+}
+
+object ShowNotifications {
+    var isPending = false
 }
 
 interface NotificationsView {


### PR DESCRIPTION
### :pushpin: References
* **Issue:**  https://app.clickup.com/t/8693p4eqg #8693p4eqg
* **Related Pull request:** 

Sorry, the branch name is bad named as simpritnts instead of widp

###   :gear: branches 
**app**: 

       Origin: feature-simprints/avoid_launch_the_same_notification_twice Target: develop-widp
**dhis2-android-SDK**: 
       Origin:develop-eyeseetea

### :tophat: What is the goal?

Show notification from either screen to start the app

### :memo: How is it being implemented?

- [x] launch notification in MainActivity only if items in list is greater than 1
- [x] launch notification in automatic next scree if items in main activity is equal to 1

### :boom: How can it be tested?



### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-