### PR TITLE
[SPIP] Fix ProvideInputDate using date in USA format

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/providers/InputFieldsProvider.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/providers/InputFieldsProvider.kt
@@ -149,6 +149,10 @@ fun manageActionBasedOnValue(uiModel: EventInputDateUiModel, dateString: String)
 private fun isValid(valueString: String) = valueString.length == 8
 
 private fun formatStoredDateToUI(dateValue: String): String? {
+    if (dateValue.isNullOrEmpty()) {
+        return null
+    }
+
     val date = DateTime.parse(dateValue, DateTimeFormat.forPattern(SIMPLE_DATE_FORMAT))
 
     return date.toString(DateTimeFormat.forPattern("yyyyMMdd"))


### PR DESCRIPTION
### :pushpin: References
* **Issue:**  https://app.clickup.com/t/8696x4pa0 #8696x4pa0
* **Related Pull request:** 

###   :gear: branches 
**app**: 
       Origin: fix-spip/date_input_us_formatTarget: develop-spip
**dhis2-android-SDK**: 
       Origin: afc8d608e4db47d23b83cb8b487061392d0e5bbb

### :tophat: What is the goal?

Show date in American format to create an event

### :memo: How is it being implemented?

- [x] Fix ProvideInputDate using date in USA format

### :boom: How can it be tested?


The app should send all data values with value again to the server

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-
![Screenshot_20250130_121156](https://github.com/user-attachments/assets/3217445d-c3c4-43d6-b735-e7bf346f7423)
