### PR TITLE
[Simprints] Change to retrieve logged user from the database

### DIFF
--- a/app/src/main/java/org/dhis2/data/biometrics/BiometricsClient.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/BiometricsClient.kt
@@ -55,18 +55,18 @@ sealed class VerifyResult {
 
 class BiometricsClient(
     projectId: String,
-    userId: String,
+    user: String,
     private val confidenceScoreFilter: Int
 ) {
 
     init {
         Timber.d("BiometricsClient!")
-        Timber.d("userId: $userId")
+        Timber.d("userId: $user")
         Timber.d("projectId: $projectId")
         Timber.d("confidenceScoreFilter: $confidenceScoreFilter")
     }
 
-    private val simHelper = SimHelper(projectId, userId)
+    private val simHelper = SimHelper(projectId, user)
     private val defaultModuleId = "NA"
 
     fun register(activity: Activity, moduleId: String, ageInMonths: Long) {

--- a/app/src/main/java/org/dhis2/data/biometrics/BiometricsClientFactory.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/BiometricsClientFactory.kt
@@ -4,18 +4,23 @@ import android.content.Context
 import org.dhis2.commons.biometrics.BiometricsPreference.Companion.CONFIDENCE_SCORE_FILTER
 import org.dhis2.commons.biometrics.BiometricsPreference.Companion.PROJECT_ID
 import org.dhis2.commons.prefs.BasicPreferenceProviderImpl
-import org.dhis2.commons.prefs.PreferenceProviderImpl
-import org.dhis2.commons.prefs.SECURE_USER_NAME
+import org.hisp.dhis.android.core.D2Manager
 
 object BiometricsClientFactory {
     fun get( context:Context):BiometricsClient{
         val basicPreferences = BasicPreferenceProviderImpl(context)
-        val preferences = PreferenceProviderImpl(context)
 
         val projectId = basicPreferences.getString(PROJECT_ID,"Ma9wi0IBdo215PKRXOf5")!!
-        val userId = preferences.getString(SECURE_USER_NAME,"")!!
+        val username = getUsername()
         val confidenceScoreFilter = basicPreferences.getInt(CONFIDENCE_SCORE_FILTER,0)
 
-        return BiometricsClient(projectId, userId, confidenceScoreFilter)
+        return BiometricsClient(projectId, username, confidenceScoreFilter)
+    }
+
+    private fun getUsername(): String {
+        val user = D2Manager.getD2().userModule().user().blockingGet()
+
+        val userId = user?.username() ?: "admin"
+        return userId
     }
 }


### PR DESCRIPTION

### :pushpin: References
* **Issue:**  https://app.clickup.com/t/8697jxz0u #8697jxz0u
* **Related Pull request:** 

###   :gear: branches 
**app**: 
       Origin: feature-simprints/remove_call_to_none_of_above Target: develop-simprints
**dhis2-android-SDK**: 
       Origin: 148a1f72eb93b2382e26e83f340dd32620a66c4e

### :tophat: What is the goal?

Client report that sometimes user id passed to SID is empty. I've changed the approach to retrieve the user from share preferences to database

### :memo: How is it being implemented?

- [x]  Retrieve logged user from the database to pass to SID

Important: 

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
