### PR TITLE
[Simprints] Add new restriction as select org unit as module Id

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/biometrics/OrgUnitAsModuleId.kt
+++ b/app/src/main/java/org/dhis2/usescases/biometrics/OrgUnitAsModuleId.kt
@@ -15,24 +15,38 @@ fun getOrgUnitAsModuleId(
         basicPreferenceProvider.getInt(BiometricsPreference.ORG_UNIT_LEVEL_AS_MODULE_ID, 0)
 
     val path = orgUnit?.path() ?: selectedOrgUnitUid
+    val level = orgUnit?.level() ?: 0
 
-    return getOrgUnitAsModuleIdByPath(selectedOrgUnitUid, path, orgUnitLevelAsModuleId)
+    return getOrgUnitAsModuleIdByPath(selectedOrgUnitUid, level, path, orgUnitLevelAsModuleId)
 }
 
 fun getOrgUnitAsModuleIdByPath(
     selectedOrgUnitUid: String,
+    selectedOrgUnitLevel: Int,
     path: String,
     orgUnitLevelAsModuleId: Int
 ): String {
-    val pathList = path.split("/")
+    val maxOrgUnitLevelAsModuleId = 4
+
+    val pathList = path.split("/").filter { it.isNotBlank() }
 
     return if (pathList.contains(selectedOrgUnitUid)) {
+
+        val orgUnitLevelsPath = (1..selectedOrgUnitLevel).toList()
+
         val pathIndexToSelect = pathList.indexOf(selectedOrgUnitUid) + orgUnitLevelAsModuleId
 
-        if (pathIndexToSelect < 0) {
+        if (pathIndexToSelect < 0){
             pathList[0]
-        } else{
-            pathList[pathIndexToSelect]
+        } else {
+            val pathLevel = orgUnitLevelsPath[pathIndexToSelect]
+
+            if (pathLevel > maxOrgUnitLevelAsModuleId) {
+                val maxIndex = orgUnitLevelsPath.indexOf(maxOrgUnitLevelAsModuleId)
+                pathList[maxIndex]
+            } else{
+                pathList[pathIndexToSelect]
+            }
         }
     } else {
         selectedOrgUnitUid

--- a/app/src/test/java/org/dhis2/usescases/biometrics/OrgUnitAsModuleIdTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/biometrics/OrgUnitAsModuleIdTest.kt
@@ -8,41 +8,120 @@ class OrgUnitAsModuleIdTest {
     private val orgUnit1 = "orgUnit1"
     private val orgUnit2 = "orgUnit2"
     private val orgUnit3 = "orgUnit3"
+    private val orgUnit4 = "orgUnit4"
+    private val orgUnit5 = "orgUnit5"
+    private val orgUnit6 = "orgUnit6"
 
-    private val path = "$orgUnit1/$orgUnit2/$orgUnit3"
+    private val pathOrgUnit1 = "/$orgUnit1"
+    private val pathOrgUnit2 = "/$orgUnit1/$orgUnit2"
+    private val pathOrgUnit3 = "/$orgUnit1/$orgUnit2/$orgUnit3"
+    private val pathOrgUnit4 = "/$orgUnit1/$orgUnit2/$orgUnit3/$orgUnit4"
+    private val pathOrgUnit5 = "/$orgUnit1/$orgUnit2/$orgUnit3/$orgUnit4/$orgUnit5"
+    private val pathOrgUnit6 = "/$orgUnit1/$orgUnit2/$orgUnit3/$orgUnit4/$orgUnit5/$orgUnit6"
 
     @Test
-    fun `Should return the same org unit if orgUnitLevelAsModuleId is 0`() {
-        val orgUnit = getOrgUnitAsModuleIdByPath(orgUnit3, path, 0)
+    fun `Should return the same org unit if orgUnitLevelAsModuleId is 0 and org unit is of level 1`() {
+        val orgUnit = getOrgUnitAsModuleIdByPath(orgUnit1, 1, pathOrgUnit1, 0)
 
-        Assert.assertEquals(orgUnit3, orgUnit)
+        Assert.assertEquals(orgUnit1, orgUnit)
     }
 
     @Test
-    fun `Should return the parent org unit if orgUnitLevelAsModuleId is -1`() {
-        val orgUnit = getOrgUnitAsModuleIdByPath(orgUnit3, path, -1)
+    fun `Should return the same org unit if orgUnitLevelAsModuleId is 0 and org unit is of level 2`() {
+        val orgUnit = getOrgUnitAsModuleIdByPath(orgUnit2, 2, pathOrgUnit2, 0)
 
         Assert.assertEquals(orgUnit2, orgUnit)
     }
 
     @Test
-    fun `Should return the parent of the parent org unit if orgUnitLevelAsModuleId is -2`() {
-        val orgUnit = getOrgUnitAsModuleIdByPath(orgUnit3, path, -2)
+    fun `Should return the same org unit if orgUnitLevelAsModuleId is 0 and org unit is of level 3`() {
+        val orgUnit = getOrgUnitAsModuleIdByPath(orgUnit3, 3, pathOrgUnit3, 0)
+
+        Assert.assertEquals(orgUnit3, orgUnit)
+    }
+
+    @Test
+    fun `Should return the same org unit if orgUnitLevelAsModuleId is 0 and org unit is of level 4`() {
+        val orgUnit = getOrgUnitAsModuleIdByPath(orgUnit4, 4, pathOrgUnit4, 0)
+
+        Assert.assertEquals(orgUnit4, orgUnit)
+    }
+
+    @Test
+    fun `Should return max org unit level 4 if orgUnitLevelAsModuleId is 0 and org unit is of level 5`() {
+        val orgUnit = getOrgUnitAsModuleIdByPath(orgUnit5, 5, pathOrgUnit5, 0)
+
+        Assert.assertEquals(orgUnit4, orgUnit)
+    }
+
+    @Test
+    fun `Should return max org unit level 4 if orgUnitLevelAsModuleId is 0 and org unit is of level 6`() {
+        val orgUnit = getOrgUnitAsModuleIdByPath(orgUnit6, 6, pathOrgUnit6, 0)
+
+        Assert.assertEquals(orgUnit4, orgUnit)
+    }
+
+
+    @Test
+    fun `Should return parent org unit if orgUnitLevelAsModuleId is -1 and org unit is of level 2`() {
+        val orgUnit = getOrgUnitAsModuleIdByPath(orgUnit2, 2, pathOrgUnit2, -1)
+
+        Assert.assertEquals(orgUnit1, orgUnit)
+    }
+
+    @Test
+    fun `Should return parent org unit if orgUnitLevelAsModuleId is -1 and org unit is of level 3`() {
+        val orgUnit = getOrgUnitAsModuleIdByPath(orgUnit3, 3, pathOrgUnit3, -1)
+
+        Assert.assertEquals(orgUnit2, orgUnit)
+    }
+
+    @Test
+    fun `Should return parent org unit if orgUnitLevelAsModuleId is -1 and org unit is of level 4`() {
+        val orgUnit = getOrgUnitAsModuleIdByPath(orgUnit4, 4, pathOrgUnit4, -1)
+
+        Assert.assertEquals(orgUnit3, orgUnit)
+    }
+
+    @Test
+    fun `Should return parent org unit if orgUnitLevelAsModuleId is -1 and org unit is of level 5`() {
+        val orgUnit = getOrgUnitAsModuleIdByPath(orgUnit5, 5, pathOrgUnit5, -1)
+
+        Assert.assertEquals(orgUnit4, orgUnit)
+    }
+
+    @Test
+    fun `Should return max org unit level 4 if orgUnitLevelAsModuleId is -1 and org unit is of level 6`() {
+        val orgUnit = getOrgUnitAsModuleIdByPath(orgUnit6, 6, pathOrgUnit6, -1)
+
+        Assert.assertEquals(orgUnit4, orgUnit)
+    }
+
+    @Test
+    fun `Should return the parent org unit if orgUnitLevelAsModuleId is -1 and level is less than max`() {
+        val orgUnit = getOrgUnitAsModuleIdByPath(orgUnit3, 3, pathOrgUnit3, -1)
+
+        Assert.assertEquals(orgUnit2, orgUnit)
+    }
+
+    @Test
+    fun `Should return the parent of the parent org unit if orgUnitLevelAsModuleId is -2 and level is less than max`() {
+        val orgUnit = getOrgUnitAsModuleIdByPath(orgUnit3, 3, pathOrgUnit3, -2)
 
         Assert.assertEquals(orgUnit1, orgUnit)
     }
 
     @Test
     fun `Should return last parent if orgUnitLevelAsModuleId is greater than parent counts`() {
-        val orgUnit = getOrgUnitAsModuleIdByPath(orgUnit3, path, -3)
+        val orgUnit = getOrgUnitAsModuleIdByPath(orgUnit3, 3, pathOrgUnit3, -3)
 
         Assert.assertEquals(orgUnit1, orgUnit)
     }
 
     @Test
     fun `Should return selected org unit if doesn't exist in path`() {
-        val orgUnit = getOrgUnitAsModuleIdByPath("orgUnit4", path, -3)
+        val orgUnit = getOrgUnitAsModuleIdByPath("orgUnit9", 9, pathOrgUnit6, -3)
 
-        Assert.assertEquals("orgUnit4", orgUnit)
+        Assert.assertEquals("orgUnit9", orgUnit)
     }
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:**   https://app.clickup.com/t/8697rddzr #8697rddzr
* **Related Pull request:** 

###   :gear: branches 
**app**: 
       Origin: feature-simprints/simprints_call_out_modification Target: develop-simprints
**dhis2-android-SDK**: 
       Origin: 148a1f72eb93b2382e26e83f340dd32620a66c4e

### :tophat: What is the goal?

This is the org unit levels in their server:



[https://staging.chimgh.org/simtracker/api/organisationUnitLevels?fields=id,name,level](https://staging.chimgh.org/simtracker/api/organisationUnitLevels?fields=id,%20name,level)


```json
{
    "pager": {
        "page": 1,
        "total": 6,
        "pageSize": 50,
        "pageCount": 1
    },
    "organisationUnitLevels": [
        {
            "name": "National",
            "level": 1,
            "id": "k0mu9l557ee"
        },
        {
            "name": "Region",
            "level": 2,
            "id": "Gcb8FjZDpRn"
        },
        {
            "name": "District",
            "level": 3,
            "id": "vrPCbdqkFFM"
        },
        {
            "name": "Subdistrict",
            "level": 4,
            "id": "LfYMQtBTEeK"
        },
        {
            "name": "Facility",
            "level": 5,
            "id": "OSvYGTSn5jf"
        },
        {
            "name": "Community",
            "level": 6,
            "id": "HTq42ZET38X"
        }
    ]
}
```

According to the current logic and comment of the client: 

Case 1: If the select org unit for the enrollment is of level 6 (community) and orgUnitLevelAsModuleId=-1 in data store config.

It is wrong to send the org unit of level 5 (facility) as moduleId and in this case, we should send level 4 parent

Case 2: if the select org unit for the enrollment is of level 5 (community) and orgUnitLevelAsModuleId=-1 in data store config.

It is ok to send the org unit of level 4 as moduleId

Then the logic to apply is that the orgUnit to send should be at least 4, that is to say that the unique org units accepted as module id should be of level 1,2,3,4 but never 5 or 6.

### :memo: How is it being implemented?

- [x] Modify logic to select org unit as module 1 adding new restriction
- [x] Add more tests

Important: 

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
