### PR TITLE
[Simprints] Modify Module Id Logic in identification when there are multiple org units

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,7 +88,7 @@ android {
         val mapboxAccessToken = System.getenv("MAPBOX_ACCESS_TOKEN") ?: defMapboxToken
         val bitriseSentryDSN = System.getenv("SENTRY_DSN") ?: ""
 
-        buildConfigField("String", "SDK_VERSION", "\"" + "1.10.0-eyeseetea-fork-1" + "\"")
+        buildConfigField("String", "SDK_VERSION", "\"" + "1.10.1-eyeseetea-fork-1" + "\"")
         buildConfigField("String", "MAPBOX_ACCESS_TOKEN", "\"" + mapboxAccessToken + "\"")
         buildConfigField("String", "MATOMO_URL", "\"https://usage.analytics.dhis2.org/matomo.php\"")
         buildConfigField("long", "VERSION_CODE", "${defaultConfig.versionCode}")

--- a/app/src/main/java/org/dhis2/data/biometrics/BiometricsClient.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/BiometricsClient.kt
@@ -54,7 +54,6 @@ sealed class VerifyResult {
     data object AgeGroupNotSupported : VerifyResult()
 }
 
-
 class BiometricsClient(
     projectId: String,
     user: String,
@@ -69,7 +68,6 @@ class BiometricsClient(
     }
 
     private val simHelper = SimHelper(projectId, user)
-    private val defaultModuleId = "NA"
 
     fun register(
         activity: Activity,
@@ -140,7 +138,7 @@ class BiometricsClient(
     }
 
     fun identify(activity: Activity, moduleId: String?, userOrgUnits: List<String>) {
-        val finalModuleId = moduleId ?: defaultModuleId
+        val finalModuleId = moduleId ?: DefaultModuleId
 
         Timber.d("Biometrics identify!")
         Timber.d("moduleId: $finalModuleId")
@@ -443,7 +441,7 @@ class BiometricsClient(
         enrollingOrgUnitName: String,
         userOrgUnits: List<String>
     ): Intent {
-        val finalModuleId = moduleId ?: defaultModuleId
+        val finalModuleId = moduleId ?: DefaultModuleId
 
         Timber.d("Biometrics confirmIdentify!")
         Timber.d("moduleId: $finalModuleId")
@@ -572,6 +570,8 @@ class BiometricsClient(
     }
 
     companion object {
+        const val DefaultModuleId = "NA"
+
         const val SIMPRINTS_TRACKED_ENTITY_INSTANCE_ID = "trackedEntityInstanceId"
         const val SIMPRINTS_ENROLLING_ORG_UNIT_ID = "enrollingOrgUnitId"
         const val SIMPRINTS_ENROLLING_ORG_UNIT_NAME = "enrollingOrgUnitName"

--- a/app/src/main/java/org/dhis2/usescases/biometrics/OrgUnitAsModuleIdByList.kt
+++ b/app/src/main/java/org/dhis2/usescases/biometrics/OrgUnitAsModuleIdByList.kt
@@ -1,0 +1,51 @@
+package org.dhis2.usescases.biometrics
+
+import org.dhis2.data.biometrics.BiometricsClient
+import org.hisp.dhis.android.core.D2
+
+fun getOrgUnitAsModuleIdByList(
+    selectedOrgUnitUIds: List<String>,
+    d2: D2
+): String {
+    val basicInfoOrgUnits: List<BasicInfoOrgUnit> = selectedOrgUnitUIds.map {
+        val orgUnit = d2.organisationUnitModule().organisationUnits().uid(it).blockingGet()
+        BasicInfoOrgUnit(orgUnit?.uid() ?: "", orgUnit?.level() ?: 0, orgUnit?.path() ?: it)
+    }
+
+    return getOrgUnitAsModuleIdByBasicInfo(basicInfoOrgUnits)
+}
+
+data class BasicInfoOrgUnit(
+    val uid: String,
+    val level: Int,
+    val path: String
+)
+
+fun getOrgUnitAsModuleIdByBasicInfo(orgUnits: List<BasicInfoOrgUnit>): String {
+    val level4Parents = orgUnits.map {
+                getLevel4DistrictParent(it.level, it.path)
+            }
+            .filter { it.isNotBlank() }
+            .distinct()
+
+    return if (level4Parents.size == 1) {
+        return level4Parents.first()
+    } else {
+        return BiometricsClient.DefaultModuleId
+    }
+}
+
+fun getLevel4DistrictParent(
+    currentLevel: Int,
+    path: String,
+): String {
+    val pathList = path.split("/").filter { it.isNotBlank() }
+
+    if (currentLevel < 4 || path.isBlank() || pathList.size < 4) {
+        return ""
+    }
+
+    val level4Distance = currentLevel - 4
+
+    return pathList.getOrNull(pathList.size - level4Distance - 1) ?: ""
+}

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
@@ -8,6 +8,7 @@ import static org.dhis2.commons.matomo.Actions.SYNC_TEI;
 import static org.dhis2.commons.matomo.Categories.SEARCH;
 import static org.dhis2.commons.matomo.Categories.TRACKER_LIST;
 import static org.dhis2.commons.matomo.Labels.CLICK;
+import static org.dhis2.usescases.biometrics.OrgUnitAsModuleIdByListKt.getOrgUnitAsModuleIdByList;
 import static org.dhis2.usescases.biometrics.OrgUnitAsModuleIdKt.getOrgUnitAsModuleId;
 import static org.dhis2.usescases.teiDashboard.dashboardfragments.relationships.RelationshipFragment.TEI_A_UID;
 import static org.dhis2.utils.analytics.AnalyticsConstants.ADD_RELATIONSHIP;
@@ -41,6 +42,7 @@ import org.dhis2.commons.resources.ColorUtils;
 import org.dhis2.commons.resources.ObjectStyleUtils;
 import org.dhis2.commons.resources.ResourceManager;
 import org.dhis2.commons.schedulers.SchedulerProvider;
+import org.dhis2.data.biometrics.BiometricsClient;
 import org.dhis2.data.biometrics.BiometricsClientFactory;
 import org.dhis2.data.biometrics.SimprintsItem;
 import org.dhis2.data.service.SyncStatusController;
@@ -425,7 +427,9 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
         List<String> userOrgUnits = searchRepository.getUserOrgUnits(selectedProgram.uid());
 
         if (userOrgUnits.size() > 1) {
-            view.launchBiometricsIdentify(null, userOrgUnits);
+            String orgUnitAsModuleId = getOrgUnitAsModuleIdByList(userOrgUnits, d2);
+
+            view.launchBiometricsIdentify(orgUnitAsModuleId, userOrgUnits);
         } else {
             String orgUnitAsModuleId = getOrgUnitAsModuleId(userOrgUnits.get(0), d2, basicPreferenceProvider);
 

--- a/app/src/test/java/org/dhis2/usescases/biometrics/GetLevel4DistrictParent.kt
+++ b/app/src/test/java/org/dhis2/usescases/biometrics/GetLevel4DistrictParent.kt
@@ -1,0 +1,38 @@
+package org.dhis2.usescases.biometrics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GetLevel4DistrictParent {
+    @Test
+    fun `should return empty level less than 4`() {
+        val result = getLevel4DistrictParent(3, "/1/2/3")
+
+        assertTrue(result.isBlank())
+    }
+
+    @Test
+    fun `should return expected level 4 if current is 5`() {
+        val result = getLevel4DistrictParent(5, "/1/2/3/4/5")
+        assertEquals("4", result)
+    }
+
+    @Test
+    fun `should return expected level 4 if current is 6`() {
+        val result = getLevel4DistrictParent(6, "/1/2/3/4/5/6")
+        assertEquals("4", result)
+    }
+
+    @Test
+    fun `should return empty with invalid path`() {
+        val result = getLevel4DistrictParent(5, "/1/2")
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `should return empty with empty path`() {
+        val result = getLevel4DistrictParent(5, "")
+        assertEquals("", result)
+    }
+}

--- a/app/src/test/java/org/dhis2/usescases/biometrics/GetOtgUnitAsModuleIdByBasicInfo.kt
+++ b/app/src/test/java/org/dhis2/usescases/biometrics/GetOtgUnitAsModuleIdByBasicInfo.kt
@@ -1,0 +1,31 @@
+package org.dhis2.usescases.biometrics
+
+import org.dhis2.data.biometrics.BiometricsClient
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GetOtgUnitAsModuleIdByBasicInfo {
+    @Test
+    fun `should return defaultModuleId if there are different level 4 parents`() {
+        val result = getOrgUnitAsModuleIdByBasicInfo(
+            listOf(
+                BasicInfoOrgUnit("6", 6, "/1/2/3/4a/5/6"),
+                BasicInfoOrgUnit("5", 5, "/1/2/3/4b/5/6")
+            )
+        )
+
+        assertEquals(BiometricsClient.DefaultModuleId, result)
+    }
+
+    @Test
+    fun `should return the unique level 4 parent`() {
+        val result = getOrgUnitAsModuleIdByBasicInfo(
+            listOf(
+                BasicInfoOrgUnit("6", 6, "/1/2/3/4/5/6"),
+                BasicInfoOrgUnit("5", 5, "/1/2/3/4/5")
+            )
+        )
+
+        assertEquals("4", result)
+    }
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:**  https://app.clickup.com/t/86981k787 #86981k787
* **Related Pull request:** 

###   :gear: branches 
**app**: 
       Origin: feature-simprints/simprints_call_out_modification Target: develop-simprints
**dhis2-android-SDK**: 
       Origin: 148a1f72eb93b2382e26e83f340dd32620a66c4e

### :tophat: What is the goal?


Current Behaviour : For identification calls, module id is determined using the org unit hierarchy of the DHIS user who is logged in. If a DHIS user is tagged to multiple org units, the module id is passed as NA.

New Requirement : For identification calls, module id is determined using the org unit hierarchy of the DHIS user who is logged in. If a DHIS user is tagged to the multiple org units, find the unique level 4 and above org units and pass the sub district id if only 1 sub district is retrieved, else pass NA.

### :memo: How is it being implemented?

- [x] Modify logic
- [x] Add tests

Important: 

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
