### PR TITLE
[Simprints] Pass extra parameters as metadata

### DIFF
--- a/app/src/main/java/org/dhis2/data/biometrics/BiometricsClient.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/BiometricsClient.kt
@@ -524,16 +524,37 @@ class BiometricsClient(
         userOrgUnits: List<String>,
         ageInMonths: Long?
     ): Metadata {
-        val metadata = Metadata()
-            .put(SIMPRINTS_TRACKED_ENTITY_INSTANCE_ID, trackedEntityInstanceUId ?: "")
-            .put(SIMPRINTS_ENROLLING_ORG_UNIT_ID, enrollingOrgUnitId ?: "")
-            .put(SIMPRINTS_ENROLLING_ORG_UNIT_NAME, enrollingOrgUnitName ?: "")
-            .put(SIMPRINTS_USER_UNITS, userOrgUnits.joinToString(","))
 
-        val metadataWithAge = if (ageInMonths != null) {
-            metadata.put(SIMPRINTS_SUBJECT_AGE, ageInMonths)
+        val metadata = Metadata()
+
+        val metadataWithTei = if (trackedEntityInstanceUId != null) {
+            metadata.put(SIMPRINTS_TRACKED_ENTITY_INSTANCE_ID, trackedEntityInstanceUId)
         } else {
             metadata
+        }
+
+        val metadataWithOrgUnitId = if (enrollingOrgUnitId != null) {
+            metadataWithTei.put(SIMPRINTS_ENROLLING_ORG_UNIT_ID, enrollingOrgUnitId)
+        } else {
+            metadataWithTei
+        }
+
+        val metadataWithOrgUnitName = if (enrollingOrgUnitName != null) {
+            metadataWithOrgUnitId.put(SIMPRINTS_ENROLLING_ORG_UNIT_NAME, enrollingOrgUnitName)
+        } else {
+            metadataWithOrgUnitId
+        }
+
+        val metadataWithUserOrgUnits = if (userOrgUnits.isNotEmpty()) {
+            metadataWithOrgUnitName.put(SIMPRINTS_USER_UNITS, userOrgUnits.joinToString(","))
+        } else {
+            metadataWithOrgUnitName
+        }
+
+        val metadataWithAge = if (ageInMonths != null) {
+            metadataWithUserOrgUnits.put(SIMPRINTS_SUBJECT_AGE, ageInMonths)
+        } else {
+            metadataWithUserOrgUnits
         }
 
         printMetadata(metadataWithAge)

--- a/app/src/main/java/org/dhis2/data/biometrics/BiometricsClient.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/BiometricsClient.kt
@@ -82,22 +82,17 @@ class BiometricsClient(
     ) {
         Timber.d("Biometrics register!")
         Timber.d("moduleId: $moduleId")
-        Timber.d("subjectAge: $ageInMonths")
 
-        val extras =
-            createExtras(
+        val metadata =
+            createMetadata(
                 trackedEntityInstanceUId,
                 enrollingOrgUnitId,
                 enrollingOrgUnitName,
-                userOrgUnits
+                userOrgUnits,
+                ageInMonths,
             )
 
-        val metadata = com.simprints.libsimprints.Metadata()
-            .put("subjectAge", ageInMonths)
-
         val intent = simHelper.register(moduleId, metadata)
-
-        extras.forEach { intent.putExtra(it.key, it.value) }
 
         launchSimprintsAppFromActivity(activity, intent, BIOMETRICS_ENROLL_REQUEST)
     }
@@ -113,26 +108,17 @@ class BiometricsClient(
     ) {
         Timber.d("Biometrics register!")
         Timber.d("moduleId: $moduleId")
-        Timber.d("subjectAge: $ageInMonths")
 
-        val extras =
-            createExtras(
+        val metadata =
+            createMetadata(
                 trackedEntityInstanceUId,
                 enrollingOrgUnitId,
                 enrollingOrgUnitName,
-                userOrgUnits
+                userOrgUnits,
+                ageInMonths
             )
 
-        val intent = if (ageInMonths != null) {
-            val metadata = com.simprints.libsimprints.Metadata()
-                .put("subjectAge", ageInMonths)
-
-            simHelper.register(moduleId, metadata)
-        } else {
-            simHelper.register(moduleId)
-        }
-
-        extras.forEach { intent.putExtra(it.key, it.value) }
+        val intent = simHelper.register(moduleId, metadata)
 
         if (fragment.context != null) {
             launchSimprintsAppFromFragment(fragment, intent, BIOMETRICS_ENROLL_REQUEST)
@@ -145,16 +131,15 @@ class BiometricsClient(
         Timber.d("Biometrics identify!")
         Timber.d("moduleId: $finalModuleId")
 
-        val extras = createExtras(
+        val metadata = createMetadata(
             trackedEntityInstanceUId = null,
             enrollingOrgUnitId = null,
             enrollingOrgUnitName = null,
-            userOrgUnits = userOrgUnits
+            userOrgUnits = userOrgUnits,
+            ageInMonths = null
         )
 
-        val intent = simHelper.identify(finalModuleId)
-
-        extras.forEach { intent.putExtra(it.key, it.value) }
+        val intent = simHelper.identify(finalModuleId, metadata)
 
         launchSimprintsAppFromActivity(activity, intent, BIOMETRICS_IDENTIFY_REQUEST)
     }
@@ -177,32 +162,22 @@ class BiometricsClient(
 
         Timber.d("Biometrics verify!")
         Timber.d("moduleId: $moduleId")
-        Timber.d("subjectAge: $ageInMonths")
 
-        val extras =
-            createExtras(
+        val metadata =
+            createMetadata(
                 trackedEntityInstanceUId,
                 enrollingOrgUnitId,
                 enrollingOrgUnitName,
-                userOrgUnits
+                userOrgUnits,
+                ageInMonths
             )
 
-        val intent = if (ageInMonths != null) {
-            val metadata = com.simprints.libsimprints.Metadata()
-                .put("subjectAge", ageInMonths)
-
-            simHelper.verify(moduleId, guid, metadata)
-        } else {
-            simHelper.verify(moduleId, guid)
-        }
-
-        extras.forEach { intent.putExtra(it.key, it.value) }
+        val intent = simHelper.verify(moduleId, guid, metadata)
 
         if (fragment.context != null) {
             launchSimprintsAppFromFragment(fragment, intent, BIOMETRICS_VERIFY_REQUEST)
         }
     }
-
 
     fun handleRegisterResponse(resultCode: Int, data: Intent): RegisterResult {
         Timber.d("Result code: $resultCode")
@@ -348,16 +323,18 @@ class BiometricsClient(
         activity: Activity,
         sessionId: String,
         guid: String,
-        extras: Map<String, String>
+        trackedEntityInstanceUId: String
     ) {
         Timber.d("Biometrics confirmIdentify!")
         Timber.d("sessionId: $sessionId")
         Timber.d("guid: $guid")
-        printExtras(extras)
+        Timber.d(SIMPRINTS_TRACKED_ENTITY_INSTANCE_ID, trackedEntityInstanceUId)
 
-        val intent = simHelper.confirmIdentity(sessionId, guid)
+        val metadata = Metadata()
+            .put(SIMPRINTS_TRACKED_ENTITY_INSTANCE_ID, trackedEntityInstanceUId)
 
-        extras.forEach { intent.putExtra(it.key, it.value) }
+        val intent = simHelper.confirmIdentity(sessionId, guid).putExtra(
+            Constants.SIMPRINTS_METADATA, metadata.toString())
 
         launchSimprintsAppFromActivity(activity, intent, BIOMETRICS_CONFIRM_IDENTITY_REQUEST)
     }
@@ -366,16 +343,18 @@ class BiometricsClient(
         fragment: Fragment,
         sessionId: String,
         guid: String,
-        extras: Map<String, String>
+        trackedEntityInstanceUId: String
     ) {
         Timber.d("Biometrics confirmIdentify!")
         Timber.d("sessionId: $sessionId")
         Timber.d("guid: $guid")
-        printExtras(extras)
+        Timber.d(SIMPRINTS_TRACKED_ENTITY_INSTANCE_ID, trackedEntityInstanceUId)
 
-        val intent = simHelper.confirmIdentity(sessionId, guid)
+        val metadata = Metadata()
+            .put(SIMPRINTS_TRACKED_ENTITY_INSTANCE_ID, trackedEntityInstanceUId)
 
-        extras.forEach { intent.putExtra(it.key, it.value) }
+        val intent = simHelper.confirmIdentity(sessionId, guid).putExtra(
+            Constants.SIMPRINTS_METADATA, metadata.toString())
 
         launchSimprintsAppFromFragment(fragment, intent, BIOMETRICS_CONFIRM_IDENTITY_REQUEST)
     }
@@ -413,13 +392,15 @@ class BiometricsClient(
         launchSimprintsAppFromActivity(activity, intent, BIOMETRICS_ENROLL_LAST_REQUEST)
     }
 
-    fun registerLastFromFragment(fragment: Fragment, sessionId: String,
-                                 moduleId: String?,
-                                 ageInMonths: Long? = null,
-                                 trackedEntityInstanceUId: String,
-                                 enrollingOrgUnitId: String,
-                                 enrollingOrgUnitName: String,
-                                 userOrgUnits: List<String>) {
+    fun registerLastFromFragment(
+        fragment: Fragment, sessionId: String,
+        moduleId: String?,
+        ageInMonths: Long? = null,
+        trackedEntityInstanceUId: String,
+        enrollingOrgUnitId: String,
+        enrollingOrgUnitName: String,
+        userOrgUnits: List<String>
+    ) {
 
         val intent = createRegisterLastIntent(
             moduleId,
@@ -448,26 +429,17 @@ class BiometricsClient(
         Timber.d("Biometrics confirmIdentify!")
         Timber.d("moduleId: $finalModuleId")
         Timber.d("sessionId: $sessionId")
-        Timber.d("subjectAge: $ageInMonths")
 
-        val extras =
-            createExtras(
+        val metadata =
+            createMetadata(
                 trackedEntityInstanceUId,
                 enrollingOrgUnitId,
                 enrollingOrgUnitName,
-                userOrgUnits
+                userOrgUnits,
+                ageInMonths
             )
 
-        val intent = if (ageInMonths != null) {
-            val metadata = Metadata()
-                .put("subjectAge", ageInMonths)
-
-            simHelper.registerLastBiometrics(finalModuleId, sessionId, metadata)
-        } else {
-            simHelper.registerLastBiometrics(finalModuleId, sessionId)
-        }
-
-        extras.forEach { intent.putExtra(it.key, it.value) }
+        val intent = simHelper.registerLastBiometrics(finalModuleId, sessionId, metadata)
 
         return intent
     }
@@ -545,30 +517,32 @@ class BiometricsClient(
         }
     }
 
-    private fun createExtras(
+    private fun createMetadata(
         trackedEntityInstanceUId: String?,
         enrollingOrgUnitId: String?,
         enrollingOrgUnitName: String?,
-        userOrgUnits: List<String>
-    ): Map<String, String?> {
-        val extras: HashMap<String, String?> = HashMap()
+        userOrgUnits: List<String>,
+        ageInMonths: Long?
+    ): Metadata {
+        val metadata = Metadata()
+            .put(SIMPRINTS_TRACKED_ENTITY_INSTANCE_ID, trackedEntityInstanceUId ?: "")
+            .put(SIMPRINTS_ENROLLING_ORG_UNIT_ID, enrollingOrgUnitId ?: "")
+            .put(SIMPRINTS_ENROLLING_ORG_UNIT_NAME, enrollingOrgUnitName ?: "")
+            .put(SIMPRINTS_USER_UNITS, userOrgUnits.joinToString(","))
 
-        extras[SIMPRINTS_TRACKED_ENTITY_INSTANCE_ID] = trackedEntityInstanceUId
-        extras[SIMPRINTS_ENROLLING_ORG_UNIT_ID] = enrollingOrgUnitId
-        extras[SIMPRINTS_ENROLLING_ORG_UNIT_NAME] = enrollingOrgUnitName
-        extras[SIMPRINTS_USER_UNITS] = userOrgUnits?.joinToString(",")
+        val metadataWithAge = if (ageInMonths != null) {
+            metadata.put(SIMPRINTS_SUBJECT_AGE, ageInMonths)
+        } else {
+            metadata
+        }
 
-        printExtras(extras)
+        printMetadata(metadataWithAge)
 
-        return extras
+        return metadataWithAge
     }
 
-    private fun printExtras(extras: Map<String, String?>) {
-        Timber.d("extras:")
-
-        extras.entries.forEach {
-            Timber.d("${it.key}: ${it.value}")
-        }
+    private fun printMetadata(metadata: Metadata) {
+        Timber.d("metadata: $metadata")
     }
 
     companion object {
@@ -576,6 +550,7 @@ class BiometricsClient(
         const val SIMPRINTS_ENROLLING_ORG_UNIT_ID = "enrollingOrgUnitId"
         const val SIMPRINTS_ENROLLING_ORG_UNIT_NAME = "enrollingOrgUnitName"
         const val SIMPRINTS_USER_UNITS = "userOrgUnits"
+        const val SIMPRINTS_SUBJECT_AGE = "subjectAge"
     }
 }
 

--- a/app/src/main/java/org/dhis2/usescases/biometrics/duplicates/BiometricsDuplicatesDialog.kt
+++ b/app/src/main/java/org/dhis2/usescases/biometrics/duplicates/BiometricsDuplicatesDialog.kt
@@ -40,7 +40,6 @@ import org.dhis2.bindings.app
 import org.dhis2.commons.biometrics.BIOMETRICS_CONFIRM_IDENTITY_REQUEST
 import org.dhis2.commons.data.SearchTeiModel
 import org.dhis2.commons.resources.ColorUtils
-import org.dhis2.data.biometrics.BiometricsClient
 import org.dhis2.data.biometrics.BiometricsClientFactory.get
 import org.dhis2.data.biometrics.SimprintsItem
 import org.dhis2.databinding.DialogBiometricsDuplicatesBinding
@@ -222,10 +221,7 @@ class BiometricsDuplicatesDialog : DialogFragment(), BiometricsDuplicatesDialogV
     ) {
         lastSelection = LastSelection(teiUid, enrollmentUid, isOnline)
 
-        val extras =
-            mutableMapOf(BiometricsClient.SIMPRINTS_TRACKED_ENTITY_INSTANCE_ID to teiUid)
-
-        context?.let { get(it).confirmIdentify(this, sessionId, guid, extras) }
+        context?.let { get(it).confirmIdentify(this, sessionId, guid, teiUid) }
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.java
@@ -464,10 +464,7 @@ public class SearchTEActivity extends ActivityGlobalAbstract implements SearchTE
     public void sendBiometricsConfirmIdentity(String sessionId, String guid, String teiUid,
                                               String enrollmentUid, boolean isOnline) {
         if (lastSelection != null) {
-            HashMap extras = new HashMap<>();
-            extras.put(BiometricsClient.SIMPRINTS_TRACKED_ENTITY_INSTANCE_ID, lastSelection.getTei().uid());
-
-            BiometricsClientFactory.INSTANCE.get(this).confirmIdentify(this, sessionId, guid, extras);
+            BiometricsClientFactory.INSTANCE.get(this).confirmIdentify(this, sessionId, guid, lastSelection.getTei().uid());
             viewModel.clearQueryData();
         }
     }


### PR DESCRIPTION
### :pushpin: References
* **Issue:**  https://app.clickup.com/t/86981kgcy #86981kgcy
* **Related Pull request:** 

###   :gear: branches 
**app**: 
       Origin: :feature-simprints/pass_new_parameters_as_metadata Target: develop-simprints
**dhis2-android-SDK**: 
       Origin: 148a1f72eb93b2382e26e83f340dd32620a66c4e

### :tophat: What is the goal?

We do not see the newly added parameters in the backend logs - SID logs only the required extras + metadata. Any other extras are just acknowledged by a SuspiciousIntent event but it doesn’t log the “extra extras” themselves.
Regarding the comment that the Metadata’s “possible parameters” don’t include anything besides subjectAge - we have only documented subjectAge as this is the only one currently having an expected use in SID. However, there’s no limit on what keys you save in the Metadata. The only limitation is on the types where we don’t allow dictionaries and arrays.
You can see doc about it here: https://simprints.gitbook.io/docs/development/simprints-for-developers/integrating-with-simprints/metadata
You need to add to the callout a single extra with key “metadata” and value in the format:
{
 "userOrgUnits": "TZL4SY7oBv3",
 "enrollingOrgUnitName": "Central Combine",
 "enrollingOrgUnitId": "TZL4SY7oBv3",
 "subjectAge": 530
}

so it appears we might need to make a change on our end for them to be able to consume the newly added parameters

### :memo: How is it being implemented?

- [x] Pass parameters as metadata

Important: 

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
