### PR TITLE
[WIDP] Improvements in notifications

### DIFF
--- a/app/src/androidTest/java/org/dhis2/common/db/TestingDatabase.kt
+++ b/app/src/androidTest/java/org/dhis2/common/db/TestingDatabase.kt
@@ -30,7 +30,7 @@ class TestingDatabase : BaseTest() {
         /* Download db */
         val d2 = D2Manager.blockingInstantiateD2(ServerModule.getD2Configuration(ApplicationProvider.getApplicationContext<AppTest>()))
         d2?.userModule()
-            ?.logIn(username, password, url)
+            ?.logIn(username, password, url, null)
             ?.blockingGet()
         d2?.metadataModule()?.blockingDownload()
 

--- a/app/src/main/java/org/dhis2/usescases/main/MainActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/main/MainActivity.kt
@@ -498,6 +498,7 @@ class MainActivity :
             R.id.sync_manager -> {
                 presenter.onClickSyncManager()
                 mainNavigator.openSettings()
+                notificationsPresenter.markShowNotificationsAsPending()
             }
 
             R.id.qr_scan -> {
@@ -526,6 +527,7 @@ class MainActivity :
 
             R.id.menu_home -> {
                 mainNavigator.openHome(binding.navigationBar)
+                notificationsPresenter.refresh(this)
             }
 
             R.id.menu_troubleshooting -> {

--- a/app/src/test/java/org/dhis2/data/notifications/NotificationD2RepositoryTest.kt
+++ b/app/src/test/java/org/dhis2/data/notifications/NotificationD2RepositoryTest.kt
@@ -1,0 +1,330 @@
+package org.dhis2.data.notifications
+
+import org.dhis2.commons.prefs.BasicPreferenceProvider
+import org.dhis2.commons.prefs.Preference.Companion.NOTIFICATIONS
+import org.dhis2.usescases.notifications.domain.Notification
+import org.dhis2.usescases.notifications.domain.ReadBy
+import org.dhis2.usescases.notifications.domain.Recipients
+import org.dhis2.usescases.notifications.domain.Ref
+import org.dhis2.usescases.notifications.domain.UserGroups
+import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.user.User
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import retrofit2.Call
+import retrofit2.Response
+import java.util.Date
+
+@RunWith(MockitoJUnitRunner::class)
+class NotificationD2RepositoryTest {
+    private val d2: D2 = Mockito.mock(D2::class.java, Mockito.RETURNS_DEEP_STUBS)
+
+    @Mock
+    lateinit var basicPreferenceProvider: BasicPreferenceProvider
+
+    @Mock
+    lateinit var notificationsApi: NotificationsApi
+
+    @Mock
+    lateinit var userGroupsApi: UserGroupsApi
+
+    val user = givenAnUser()
+
+    @Test
+    fun `Should sync empty notifications if it's empty in remote`() {
+        val repository = givenTestData(user, listOf(), UserGroups(userGroups = listOf()))
+
+        repository.sync()
+
+        verify(basicPreferenceProvider).saveAsJson(
+            NOTIFICATIONS,
+            listOf<Notification>(),
+        )
+    }
+
+    @Test
+    fun `Should sync notifications with all receivers`() {
+        val notifications = listOf(givenANotification(wildcard = "ALL"))
+
+        val repository = givenTestData(user, notifications, UserGroups(userGroups = listOf()))
+
+        repository.sync()
+
+        verify(basicPreferenceProvider).saveAsJson(
+            NOTIFICATIONS,
+            notifications,
+        )
+    }
+
+    @Test
+    fun `Should sync notifications with android receivers and for specific user`() {
+        val notifications = listOf(
+            givenANotification(
+                wildcard = "Android",
+                users = listOf(Ref(id = user.uid(), name = null))
+            )
+        )
+
+        val repository = givenTestData(user, notifications, UserGroups(userGroups = listOf()))
+
+        repository.sync()
+
+        verify(basicPreferenceProvider).saveAsJson(
+            NOTIFICATIONS,
+            notifications,
+        )
+    }
+
+    @Test
+    fun `Should sync notifications with android receivers and for specific userGroup`() {
+        val notifications = listOf(
+            givenANotification(
+                wildcard = "Android",
+                userGroups = arrayListOf(Ref(id = "userGroup1", name = null))
+            )
+        )
+
+        val repository = givenTestData(
+            user,
+            notifications,
+            UserGroups(userGroups = listOf(Ref(id = "userGroup1", name = null)))
+        )
+
+        repository.sync()
+
+        verify(basicPreferenceProvider).saveAsJson(
+            NOTIFICATIONS,
+            notifications,
+        )
+    }
+
+    @Test
+    fun `Should sync notifications with both receivers and for specific user`() {
+        val notifications = listOf(
+            givenANotification(
+                wildcard = "Both",
+                users = listOf(Ref(id = user.uid(), name = null))
+            )
+        )
+
+        val repository = givenTestData(user, notifications, UserGroups(userGroups = listOf()))
+
+        repository.sync()
+
+        verify(basicPreferenceProvider).saveAsJson(
+            NOTIFICATIONS,
+            notifications,
+        )
+    }
+
+    @Test
+    fun `Should sync notifications with both receivers and for specific userGroup`() {
+        val notifications = listOf(
+            givenANotification(
+                wildcard = "both",
+                userGroups = arrayListOf(Ref(id = "userGroup1", name = null))
+            )
+        )
+
+        val repository = givenTestData(
+            user,
+            notifications,
+            UserGroups(userGroups = listOf(Ref(id = "userGroup1", name = null)))
+        )
+
+        repository.sync()
+
+        verify(basicPreferenceProvider).saveAsJson(
+            NOTIFICATIONS,
+            notifications,
+        )
+    }
+
+    @Test
+    fun `Should not sync notifications with web receivers and for specific user`() {
+        val notifications = listOf(
+            givenANotification(
+                wildcard = "Web",
+                users = listOf(Ref(id = user.uid(), name = null))
+            )
+        )
+
+        val repository = givenTestData(user, notifications, UserGroups(userGroups = listOf()))
+
+        repository.sync()
+
+        verify(basicPreferenceProvider).saveAsJson(
+            NOTIFICATIONS,
+            listOf<Notification>(),
+        )
+    }
+
+    @Test
+    fun `Should not sync notifications with web receivers and for specific userGroup`() {
+        val notifications = listOf(
+            givenANotification(
+                wildcard = "web",
+                userGroups = arrayListOf(Ref(id = "userGroup1", name = null))
+            )
+        )
+
+        val repository = givenTestData(
+            user,
+            notifications,
+            UserGroups(userGroups = listOf(Ref(id = "userGroup1", name = null)))
+        )
+
+        repository.sync()
+
+        verify(basicPreferenceProvider).saveAsJson(
+            NOTIFICATIONS,
+            listOf<Notification>(),
+        )
+    }
+
+    @Test
+    fun `Should only sync expected notifications`() {
+        val forWebByUserGroup = givenANotification(
+            wildcard = "web",
+            userGroups = arrayListOf(Ref(id = "userGroup1", name = null))
+        )
+        val forWebByUser = givenANotification(
+            wildcard = "WEB",
+            users = listOf(Ref(id = user.uid(), name = null))
+        )
+        val forBothByUserGroup = givenANotification(
+            wildcard = "Both",
+            userGroups = arrayListOf(Ref(id = "userGroup1", name = null))
+        )
+        val forBothByUser = givenANotification(
+            wildcard = "both",
+            users = listOf(Ref(id = user.uid(), name = null))
+        )
+        val forAndroidByUserGroup = givenANotification(
+            wildcard = "Android",
+            userGroups = arrayListOf(Ref(id = "userGroup1", name = null))
+        )
+        val forAndroidByUser = givenANotification(
+            wildcard = "android",
+            users = listOf(Ref(id = user.uid(), name = null))
+        )
+        val forAll = givenANotification(
+            wildcard = "All",
+        )
+
+        val notifications = listOf(
+            forWebByUserGroup,
+            forWebByUser,
+            forBothByUserGroup,
+            forBothByUser,
+            forAndroidByUserGroup,
+            forAndroidByUser,
+            forAll
+        )
+
+        val repository = givenTestData(
+            user,
+            notifications,
+            UserGroups(userGroups = listOf(Ref(id = "userGroup1", name = null)))
+        )
+
+        repository.sync()
+
+        verifySyncedNotifications(
+            forBothByUserGroup,
+            forBothByUser,
+            forAndroidByUserGroup,
+            forAndroidByUser,
+            forAll
+        )
+    }
+
+    private fun givenTestData(
+        user: User,
+        notifications: List<Notification>,
+        userGroups: UserGroups
+    ): NotificationD2Repository {
+        whenever(
+            d2.userModule().user()
+                .blockingGet(),
+        ) doReturn user
+
+        val notificationMockCall = mock<Call<List<Notification>>>()
+        whenever(notificationMockCall.execute()) doReturn Response.success(notifications)
+        whenever(notificationsApi.getData()) doReturn notificationMockCall
+
+        val mockCall = mock<Call<UserGroups>>()
+        whenever(mockCall.execute()) doReturn Response.success(userGroups)
+        whenever(userGroupsApi.getData(user.uid())) doReturn mockCall
+
+        return NotificationD2Repository(
+            d2,
+            basicPreferenceProvider,
+            notificationsApi,
+            userGroupsApi
+        )
+    }
+
+    private fun givenAnUser(): User {
+        val user = User.builder().uid("user1").build()
+
+        whenever(
+            d2.userModule().user()
+                .blockingGet(),
+        ) doReturn User.builder().uid("user1").build()
+
+        return user
+    }
+
+    private fun givenANotification(
+        readBy: List<ReadBy> = listOf(),
+        userGroups: ArrayList<Ref> = ArrayList(),
+        users: List<Ref> = listOf(),
+        wildcard: String = ""
+    ): Notification {
+        return Notification(
+            content = "test",
+            id = "1",
+            createdAt = Date(),
+            readBy = readBy,
+            recipients = Recipients(
+                userGroups = userGroups,
+                users = users,
+                wildcard = wildcard
+            )
+        )
+    }
+
+    private fun verifySyncedNotifications(
+        forBothByUserGroup: Notification,
+        forBothByUser: Notification,
+        forAndroidByUserGroup: Notification,
+        forAndroidByUser: Notification,
+        forAll: Notification
+    ) {
+        val captor = argumentCaptor<List<Notification>>()
+        verify(basicPreferenceProvider).saveAsJson(eq(NOTIFICATIONS), captor.capture())
+
+        val expectedNotifications = listOf(
+            forBothByUserGroup,
+            forBothByUser,
+            forAndroidByUserGroup,
+            forAndroidByUser,
+            forAll
+        )
+
+        assertEquals(expectedNotifications.size, captor.firstValue.size)
+        assertTrue(captor.firstValue.containsAll(expectedNotifications))
+    }
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:**  https://app.clickup.com/t/8693p3xv1 #8693p3xv1
* **Related Pull request:** 

###   :gear: branches 
**app**: 
       Origin:  Target: feature-simprints/avoid_launch_the_same_notification_twice Target: feature-widp/fix_bugs_notifications
**dhis2-android-SDK**: 
       Origin:develop-eyeseetea

### :tophat: What is the goal?

Review bugs in notifications and implement wildcard="ALL|ANDROID|WEB|BOTH". 

### :memo: How is it being implemented?

- [x] Review bugs in notifications
- [x] Implement wildcard="ALL|ANDROID|WEB|BOTH". 
- [x] Create tests

### :boom: How can it be tested?

https://github.com/user-attachments/assets/e886fe8e-c054-44a2-b87d-82d02bc318d4

https://github.com/user-attachments/assets/962a0d66-bd20-418b-9024-790e39c94663

https://github.com/user-attachments/assets/318256d1-9e02-43fb-9928-5c2275a4fd1e









### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-