### PR TITLE
[OCBA] Show value not unique as field validation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -190,14 +190,14 @@ android {
             applicationId = "ocba.com.dhis2.uat"
             dimension = "default"
             versionCode = libs.versions.vCode.get().toInt()
-            versionName = "2.9.1.1-ocbauat-fork-2"
+            versionName = "2.9.1.1-ocbauat-fork-3"
         }
 
         create("ocba") {
             applicationId = "ocba.com.dhis2"
             dimension = "default"
             versionCode = libs.versions.vCode.get().toInt()
-            versionName = "2.9.1.1-ocba-fork-2"
+            versionName = "2.9.1.1-ocba-fork-3"
         }
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -190,14 +190,14 @@ android {
             applicationId = "ocba.com.dhis2.uat"
             dimension = "default"
             versionCode = libs.versions.vCode.get().toInt()
-            versionName = "2.9.1.1-ocbauat-fork-3"
+            versionName = "2.9.1.1-ocbauat-fork-4"
         }
 
         create("ocba") {
             applicationId = "ocba.com.dhis2"
             dimension = "default"
             versionCode = libs.versions.vCode.get().toInt()
-            versionName = "2.9.1.1-ocba-fork-3"
+            versionName = "2.9.1.1-ocba-fork-4"
         }
     }
 

--- a/form/src/main/java/org/dhis2/form/ui/FormViewModel.kt
+++ b/form/src/main/java/org/dhis2/form/ui/FormViewModel.kt
@@ -181,7 +181,9 @@ class FormViewModel(
                     )
                 } else {
                     val saveResult = repository.save(action.id, action.value, action.extraData)
-                    if (saveResult?.valueStoreResult != ValueStoreResult.ERROR_UPDATING_VALUE) {
+
+                    //EyeSeeTea customization - Show unique error result as validation error
+                   /* if (saveResult?.valueStoreResult != ValueStoreResult.ERROR_UPDATING_VALUE) {
                         repository.updateValueOnList(action.id, action.value, action.valueType)
                     } else {
                         repository.updateErrorList(
@@ -190,7 +192,23 @@ class FormViewModel(
                             ),
                         )
                     }
-                    saveResult ?: StoreResult(
+                    )*/
+
+                    if (saveResult?.valueStoreResult == ValueStoreResult.VALUE_NOT_UNIQUE) {
+                        repository.updateErrorList(action.copy(error = ValueNotUniqueFailure))
+                    } else {
+                        if (saveResult?.valueStoreResult != ValueStoreResult.ERROR_UPDATING_VALUE) {
+                            repository.updateValueOnList(action.id, action.value, action.valueType)
+                        } else {
+                            repository.updateErrorList(
+                                action.copy(
+                                    error = Throwable(saveResult.valueStoreResultMessage),
+                                ),
+                            )
+                        }
+                    }
+
+                    StoreResult(
                         action.id,
                         ValueStoreResult.VALUE_CHANGED,
                     )

--- a/form/src/main/java/org/dhis2/form/ui/FormViewModel.kt
+++ b/form/src/main/java/org/dhis2/form/ui/FormViewModel.kt
@@ -301,9 +301,22 @@ class FormViewModel(
             val intent = getSaveIntent(it)
             val action = rowActionFromIntent(intent)
             val result = repository.save(it.uid, it.value, action.extraData)
-            repository.updateValueOnList(it.uid, it.value, it.valueType)
+
+            //EyeSeeTea customization - Show unique error result as validation error
+           /* repository.updateValueOnList(it.uid, it.value, it.valueType)
             repository.updateErrorList(action)
-            result
+            result*/
+            if (result?.valueStoreResult == ValueStoreResult.VALUE_NOT_UNIQUE) {
+                repository.updateErrorList(action.copy(error = ValueNotUniqueFailure))
+                StoreResult(
+                    rowAction.id,
+                    ValueStoreResult.VALUE_HAS_NOT_CHANGED,
+                )
+            } else {
+                repository.updateValueOnList(it.uid, it.value, it.valueType)
+                repository.updateErrorList(action)
+                result
+            }
         }
     } ?: StoreResult(
         rowAction.id,
@@ -778,3 +791,6 @@ class FormViewModel(
         const val TAG = "FormViewModel"
     }
 }
+
+//EyeSeeTea customization - Show unique error as validation error
+object ValueNotUniqueFailure : Throwable()

--- a/form/src/main/java/org/dhis2/form/ui/validation/FieldErrorMessageProvider.kt
+++ b/form/src/main/java/org/dhis2/form/ui/validation/FieldErrorMessageProvider.kt
@@ -2,6 +2,7 @@ package org.dhis2.form.ui.validation
 
 import android.content.Context
 import org.dhis2.form.R
+import org.dhis2.form.ui.ValueNotUniqueFailure
 import org.dhis2.form.ui.validation.failures.FieldMaskFailure
 import org.hisp.dhis.android.core.common.valuetype.validation.failures.BooleanFailure
 import org.hisp.dhis.android.core.common.valuetype.validation.failures.CoordinateFailure
@@ -47,6 +48,7 @@ class FieldErrorMessageProvider(private val context: Context) {
         is NumberFailure -> getNumberError(error)
         is FieldMaskFailure -> getFieldMaskError(error)
         is CoordinateFailure -> getCoordinateError(error)
+        is ValueNotUniqueFailure -> R.string.value_not_unique
         else -> R.string.invalid_field
     }
 

--- a/form/src/main/res/values/strings.xml
+++ b/form/src/main/res/values/strings.xml
@@ -108,4 +108,7 @@
     <string name="qr_code">QR code</string>
     <string name="bar_code">Bar code</string>
     <string name="add_location">Add location</string>
+
+<!--    EyeSeeTea customization-->
+    <string name="value_not_unique">Value is not unique</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 ndk = "21.4.7075529"
 sdk = "34"
 minSdk = "21"
-vCode = "133"
-vName = "2.9.1.1-ocba-fork-2"
+vCode = "134"
+vName = "2.9.1.1-ocba-fork-3"
 kotlinCompilerExtensionVersion = "1.5.6"
 gradle = "8.2.0"
 kotlin = '1.9.21'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 ndk = "21.4.7075529"
 sdk = "34"
 minSdk = "21"
-vCode = "134"
-vName = "2.9.1.1-ocba-fork-3"
+vCode = "135"
+vName = "2.9.1.1-ocba-fork-4"
 kotlinCompilerExtensionVersion = "1.5.6"
 gradle = "8.2.0"
 kotlin = '1.9.21'


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/8698mvnv7 #8698mvnv7
* **Related Pull request:** 


###   :gear: branches 
**app**: 
       Origin: feature-ocba/not_allow_save_not_unique_value Target: feature-ocba/avoid_harcoded_sdk_in_build_gradle 
**dhis2-android-SDK**: 
       Origin: adaf640198be3280bc98b2eb743766c18a0260c8

### :tophat: What is the goal?

Show unique attribute validation as field validation

### :memo: How is it being implemented?

- [x] Show value not unique as field validation

### :boom: How can it be tested?

There are 3 cases where the validation is fired.

1 - Change attribute and lost focus
[case-1.webm](https://github.com/user-attachments/assets/50d8be89-1493-44e8-84d1-42d89e64443b)
2 - Change attribute, lost focus and save
[case-2.webm](https://github.com/user-attachments/assets/9ba1f02a-8105-44be-8147-d3cdea615543)
3 - Change attribute and save without lost focus
[case-3.webm](https://github.com/user-attachments/assets/261822d4-2f71-4f23-b252-6b3858a9d9c4)


### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
![Screenshot_20250408_123857](https://github.com/user-attachments/assets/240e8cba-5ca6-48ff-94c4-8732a03c32f6)
![Screenshot_20250408_123908](https://github.com/user-attachments/assets/bf99f288-92a3-4a68-a3b1-e10c34187eef)
