### PR TITLE
[WIDP Android] Implementation of Wildcard=Android|Both

### DIFF
--- a/app/src/main/java/org/dhis2/data/notifications/NotificationD2Repository.kt
+++ b/app/src/main/java/org/dhis2/data/notifications/NotificationD2Repository.kt
@@ -28,8 +28,10 @@ class NotificationD2Repository(
 
             val userGroups = getUserGroups()
 
-            val userNotifications =
-                getNotificationsForCurrentUser(allNotifications, userGroups.userGroups)
+            val userNotifications = getNotificationsForCurrentUser(
+                allNotifications,
+                userGroups.userGroups
+            )
 
             preferenceProvider.saveAsJson(Preference.NOTIFICATIONS, userNotifications)
 
@@ -119,12 +121,12 @@ class NotificationD2Repository(
         }
 
         val notificationsByAll = nonReadByUserNotifications.filter { notification ->
-            notification.recipients.wildcard.lowercase() == "ALL".lowercase()
+            notification.recipients.wildcard.lowercase() == "ALL".lowercase() || notification.recipients.wildcard.lowercase().contains("ALL".lowercase())
         }
 
         val notificationsByUserGroup = nonReadByUserNotifications.filter { notification ->
-            notification.recipients.userGroups.any { userGroupIds.contains(it.id) } &&
-                    isForAndroid(notification)
+            notification.recipients.userGroups.any {
+                userGroupIds.contains(it.id) } && isForAndroid(notification)
         }
 
         val notificationsByUser = nonReadByUserNotifications.filter { notification ->
@@ -137,7 +139,9 @@ class NotificationD2Repository(
     private fun isForAndroid(notification: Notification): Boolean {
         return notification.recipients.wildcard.lowercase() == "Android".lowercase() ||
                 notification.recipients.wildcard == "" ||
-                notification.recipients.wildcard.lowercase() == "BOTH".lowercase()
+                notification.recipients.wildcard.lowercase() == "BOTH".lowercase() ||
+            notification.recipients.wildcard.lowercase().contains("Android".lowercase()) ||
+            notification.recipients.wildcard.lowercase().contains("BOTH".lowercase())
     }
 }
 

--- a/app/src/main/java/org/dhis2/data/notifications/NotificationD2Repository.kt
+++ b/app/src/main/java/org/dhis2/data/notifications/NotificationD2Repository.kt
@@ -137,6 +137,15 @@ class NotificationD2Repository(
         return (notificationsByAll + notificationsByUserGroup + notificationsByUser).distinct()
     }
 
+    /**
+      * Check if the notification is for Web
+      * ALL → all users irrespective of groups
+      * Android → only android users respecting user groups
+      * Web, only web users respecting user groups
+      * Both, both android and web users respecting user groups
+      * @param notification The notification to check
+      * @return true if the notification is for Web, false otherwise
+      **/
     private fun isForAndroid(notification: Notification): Boolean {
         val wildcard = notification.recipients.wildcard.lowercase()
         return wildcard == "Android".lowercase() ||

--- a/app/src/main/java/org/dhis2/data/notifications/NotificationD2Repository.kt
+++ b/app/src/main/java/org/dhis2/data/notifications/NotificationD2Repository.kt
@@ -121,7 +121,8 @@ class NotificationD2Repository(
         }
 
         val notificationsByAll = nonReadByUserNotifications.filter { notification ->
-            notification.recipients.wildcard.lowercase() == "ALL".lowercase() || notification.recipients.wildcard.lowercase().contains("ALL".lowercase())
+            val wildcard = notification.recipients.wildcard.lowercase()
+            wildcard == "ALL".lowercase() || wildcard.contains("ALL".lowercase())
         }
 
         val notificationsByUserGroup = nonReadByUserNotifications.filter { notification ->
@@ -137,11 +138,12 @@ class NotificationD2Repository(
     }
 
     private fun isForAndroid(notification: Notification): Boolean {
-        return notification.recipients.wildcard.lowercase() == "Android".lowercase() ||
-                notification.recipients.wildcard == "" ||
-                notification.recipients.wildcard.lowercase() == "BOTH".lowercase() ||
-            notification.recipients.wildcard.lowercase().contains("Android".lowercase()) ||
-            notification.recipients.wildcard.lowercase().contains("BOTH".lowercase())
+        val wildcard = notification.recipients.wildcard.lowercase()
+        return wildcard == "Android".lowercase() ||
+            wildcard.isEmpty() ||
+            wildcard == "BOTH".lowercase() ||
+            wildcard.contains("Android".lowercase()) ||
+            wildcard.contains("BOTH".lowercase())
     }
 }
 

--- a/app/src/main/java/org/dhis2/data/notifications/NotificationD2Repository.kt
+++ b/app/src/main/java/org/dhis2/data/notifications/NotificationD2Repository.kt
@@ -10,9 +10,6 @@ import org.dhis2.commons.prefs.BasicPreferenceProvider
 import org.dhis2.commons.prefs.Preference
 import org.dhis2.usescases.notifications.domain.Notification
 import org.dhis2.usescases.notifications.domain.NotificationRepository
-import org.dhis2.usescases.notifications.domain.NotificationWildcard.ALL
-import org.dhis2.usescases.notifications.domain.NotificationWildcard.ANDROID
-import org.dhis2.usescases.notifications.domain.NotificationWildcard.BOTH
 import org.dhis2.usescases.notifications.domain.Ref
 import org.dhis2.usescases.notifications.domain.UserGroups
 import org.hisp.dhis.android.core.D2
@@ -118,12 +115,12 @@ class NotificationD2Repository(
         }
 
         val notificationsByAll = nonReadByUserNotifications.filter { notification ->
-            notification.recipients.getWildcard() == ALL
+            notification.recipients.wildcard.lowercase() == "ALL".lowercase()
         }
 
         val notificationsByUserGroup = nonReadByUserNotifications.filter { notification ->
-            notification.recipients.userGroups.any {
-                userGroupIds.contains(it.id) } && isForAndroid(notification)
+            notification.recipients.userGroups.any { userGroupIds.contains(it.id) } &&
+                    isForAndroid(notification)
         }
 
         val notificationsByUser = nonReadByUserNotifications.filter { notification ->
@@ -134,10 +131,9 @@ class NotificationD2Repository(
     }
 
     private fun isForAndroid(notification: Notification): Boolean {
-        return notification.recipients.getWildcard() in listOf(
-            ANDROID,
-            BOTH,
-        )
+        return notification.recipients.wildcard.lowercase() == "Android".lowercase() ||
+                notification.recipients.wildcard == "" ||
+                notification.recipients.wildcard.lowercase() == "BOTH".lowercase()
     }
 }
 

--- a/app/src/main/java/org/dhis2/data/notifications/NotificationD2Repository.kt
+++ b/app/src/main/java/org/dhis2/data/notifications/NotificationD2Repository.kt
@@ -28,10 +28,7 @@ class NotificationD2Repository(
 
             val userGroups = getUserGroups()
 
-            val userNotifications = getNotificationsForCurrentUser(
-                allNotifications,
-                userGroups.userGroups
-            )
+            val userNotifications = getNotificationsForCurrentUser(allNotifications, userGroups.userGroups)
 
             preferenceProvider.saveAsJson(Preference.NOTIFICATIONS, userNotifications)
 
@@ -137,15 +134,6 @@ class NotificationD2Repository(
         return (notificationsByAll + notificationsByUserGroup + notificationsByUser).distinct()
     }
 
-    /**
-      * Check if the notification is for Web
-      * ALL → all users irrespective of groups
-      * Android → only android users respecting user groups
-      * Web, only web users respecting user groups
-      * Both, both android and web users respecting user groups
-      * @param notification The notification to check
-      * @return true if the notification is for Web, false otherwise
-      **/
     private fun isForAndroid(notification: Notification): Boolean {
         val wildcard = notification.recipients.wildcard.lowercase()
         return wildcard == "Android".lowercase() ||

--- a/app/src/main/java/org/dhis2/usescases/notifications/domain/Notification.kt
+++ b/app/src/main/java/org/dhis2/usescases/notifications/domain/Notification.kt
@@ -1,5 +1,7 @@
 package org.dhis2.usescases.notifications.domain
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import java.util.Date
 
 data class Notification(
@@ -7,7 +9,8 @@ data class Notification(
     val createdAt: Date,
     val id: String,
     val readBy: List<ReadBy>,
-    val recipients: Recipients
+    val recipients: Recipients,
+    val permissions: Permissions?,
 )
 
 data class ReadBy(
@@ -19,8 +22,11 @@ data class ReadBy(
 data class Recipients(
     val userGroups: ArrayList<Ref>,
     val users: List<Ref>,
-    val wildcard: String
-)
+    val wildcard: String,
+){
+    fun getWildcard(): NotificationWildcard? =
+        NotificationWildcard.fromValue(wildcard.lowercase())
+}
 
 data class Ref(
     val id: String,
@@ -30,3 +36,37 @@ data class Ref(
 data class UserGroups(
     val userGroups: List<Ref>,
 )
+
+data class Permissions(
+    val publicAccess: String,
+    val userAccesses: List<UserAccesses>,
+    val userGroupAccesses: List<UserGroupAccesses>,
+)
+
+data class UserAccesses(
+    val access: String,
+    val id: String,
+    val name: String,
+)
+
+data class UserGroupAccesses(
+    val access: String,
+    val id: String,
+    val name: String,
+)
+
+@Serializable
+enum class NotificationWildcard {
+    @SerialName("ALL")
+    ALL,
+    @SerialName("android")
+    ANDROID,
+    @SerialName("web")
+    WEB,
+    @SerialName("both")
+    BOTH;
+    companion object {
+        fun fromValue(value: String): NotificationWildcard? =
+            entries.find { it.name.equals(value, ignoreCase = true) }
+    }
+}

--- a/app/src/main/java/org/dhis2/usescases/notifications/domain/Notification.kt
+++ b/app/src/main/java/org/dhis2/usescases/notifications/domain/Notification.kt
@@ -1,7 +1,5 @@
 package org.dhis2.usescases.notifications.domain
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
 import java.util.Date
 
 data class Notification(
@@ -22,11 +20,8 @@ data class ReadBy(
 data class Recipients(
     val userGroups: ArrayList<Ref>,
     val users: List<Ref>,
-    val wildcard: String,
-){
-    fun getWildcard(): NotificationWildcard? =
-        NotificationWildcard.fromValue(wildcard.lowercase())
-}
+    val wildcard: String
+)
 
 data class Ref(
     val id: String,
@@ -54,19 +49,3 @@ data class UserGroupAccesses(
     val id: String,
     val name: String,
 )
-
-@Serializable
-enum class NotificationWildcard {
-    @SerialName("ALL")
-    ALL,
-    @SerialName("android")
-    ANDROID,
-    @SerialName("web")
-    WEB,
-    @SerialName("both")
-    BOTH;
-    companion object {
-        fun fromValue(value: String): NotificationWildcard? =
-            entries.find { it.name.equals(value, ignoreCase = true) }
-    }
-}

--- a/app/src/test/java/org/dhis2/data/notifications/NotificationD2RepositoryTest.kt
+++ b/app/src/test/java/org/dhis2/data/notifications/NotificationD2RepositoryTest.kt
@@ -154,6 +154,113 @@ class NotificationD2RepositoryTest {
     }
 
     @Test
+    fun `Should sync notifications with any valid receivers receivers and for specific user`()  = runBlocking{
+        val notifications = listOf(
+            givenANotification(
+                wildcard = "BOTH|AnDrOid|ALL",
+                users = listOf(Ref(id = user.uid(), name = null))
+            )
+        )
+
+        val repository = givenTestData(user, notifications, UserGroups(userGroups = listOf()))
+
+        repository.sync().first()
+
+        verify(basicPreferenceProvider).saveAsJson(
+            NOTIFICATIONS,
+            notifications,
+        )
+    }
+
+    @Test
+    fun `Should not sync notifications with any invalid receivers receivers and for specific user`()  = runBlocking{
+        val notifications = listOf(
+            givenANotification(
+                wildcard = "WEB|iOS|PALM",
+                users = listOf(Ref(id = user.uid(), name = null))
+            )
+        )
+
+        val repository = givenTestData(user, notifications, UserGroups(userGroups = listOf()))
+
+        repository.sync().first()
+
+        verify(basicPreferenceProvider).saveAsJson(
+            NOTIFICATIONS,
+            emptyList<Notification>(),
+        )
+    }
+
+    @Test
+    fun `Should sync notifications with ALL and ANDROID at the same time receivers and for specific userGroup`()  = runBlocking{
+        val notifications = listOf(
+            givenANotification(
+                wildcard = "ALL|Android",
+                userGroups = arrayListOf(Ref(id = "userGroup1", name = null))
+            )
+        )
+
+        val repository = givenTestData(
+            user,
+            notifications,
+            UserGroups(userGroups = listOf(Ref(id = "userGroup1", name = null)))
+        )
+
+        repository.sync().first()
+
+        verify(basicPreferenceProvider).saveAsJson(
+            NOTIFICATIONS,
+            notifications,
+        )
+    }
+
+    @Test
+    fun `Should sync notifications with any valid receivers and for specific userGroup`()  = runBlocking{
+        val notifications = listOf(
+            givenANotification(
+                wildcard = "ALL|AnDrOid|BoTH",
+                userGroups = arrayListOf(Ref(id = "userGroup1", name = null))
+            )
+        )
+
+        val repository = givenTestData(
+            user,
+            notifications,
+            UserGroups(userGroups = listOf(Ref(id = "userGroup1", name = null)))
+        )
+
+        repository.sync().first()
+
+        verify(basicPreferenceProvider).saveAsJson(
+            NOTIFICATIONS,
+            notifications,
+        )
+    }
+
+    @Test
+    fun `Should not sync notifications with any not valid receivers and for specific userGroup`()  = runBlocking{
+        val notifications = listOf(
+            givenANotification(
+                wildcard = "WEB|iOS|PALM",
+                userGroups = arrayListOf(Ref(id = "userGroup1", name = null))
+            )
+        )
+
+        val repository = givenTestData(
+            user,
+            notifications,
+            UserGroups(userGroups = listOf(Ref(id = "userGroup1", name = null)))
+        )
+
+        repository.sync().first()
+
+        verify(basicPreferenceProvider).saveAsJson(
+            NOTIFICATIONS,
+            emptyList<Notification>(),
+        )
+    }
+
+    @Test
     fun `Should not sync notifications with web receivers and for specific user`() = runBlocking {
         val notifications = listOf(
             givenANotification(

--- a/app/src/test/java/org/dhis2/data/notifications/NotificationD2RepositoryTest.kt
+++ b/app/src/test/java/org/dhis2/data/notifications/NotificationD2RepositoryTest.kt
@@ -154,25 +154,6 @@ class NotificationD2RepositoryTest {
     }
 
     @Test
-    fun `Should sync notifications with any valid receivers receivers and for specific user`()  = runBlocking{
-        val notifications = listOf(
-            givenANotification(
-                wildcard = "BOTH|AnDrOid|ALL",
-                users = listOf(Ref(id = user.uid(), name = null))
-            )
-        )
-
-        val repository = givenTestData(user, notifications, UserGroups(userGroups = listOf()))
-
-        repository.sync().first()
-
-        verify(basicPreferenceProvider).saveAsJson(
-            NOTIFICATIONS,
-            notifications,
-        )
-    }
-
-    @Test
     fun `Should not sync notifications with any invalid receivers receivers and for specific user`()  = runBlocking{
         val notifications = listOf(
             givenANotification(
@@ -188,52 +169,6 @@ class NotificationD2RepositoryTest {
         verify(basicPreferenceProvider).saveAsJson(
             NOTIFICATIONS,
             emptyList<Notification>(),
-        )
-    }
-
-    @Test
-    fun `Should sync notifications with ALL and ANDROID at the same time receivers and for specific userGroup`()  = runBlocking{
-        val notifications = listOf(
-            givenANotification(
-                wildcard = "ALL|Android",
-                userGroups = arrayListOf(Ref(id = "userGroup1", name = null))
-            )
-        )
-
-        val repository = givenTestData(
-            user,
-            notifications,
-            UserGroups(userGroups = listOf(Ref(id = "userGroup1", name = null)))
-        )
-
-        repository.sync().first()
-
-        verify(basicPreferenceProvider).saveAsJson(
-            NOTIFICATIONS,
-            notifications,
-        )
-    }
-
-    @Test
-    fun `Should sync notifications with any valid receivers and for specific userGroup`()  = runBlocking{
-        val notifications = listOf(
-            givenANotification(
-                wildcard = "ALL|AnDrOid|BoTH",
-                userGroups = arrayListOf(Ref(id = "userGroup1", name = null))
-            )
-        )
-
-        val repository = givenTestData(
-            user,
-            notifications,
-            UserGroups(userGroups = listOf(Ref(id = "userGroup1", name = null)))
-        )
-
-        repository.sync().first()
-
-        verify(basicPreferenceProvider).saveAsJson(
-            NOTIFICATIONS,
-            notifications,
         )
     }
 
@@ -411,7 +346,8 @@ class NotificationD2RepositoryTest {
                 userGroups = userGroups,
                 users = users,
                 wildcard = wildcard
-            )
+            ),
+            permissions = null
         )
     }
 

--- a/app/src/test/java/org/dhis2/data/notifications/NotificationD2RepositoryTest.kt
+++ b/app/src/test/java/org/dhis2/data/notifications/NotificationD2RepositoryTest.kt
@@ -154,48 +154,6 @@ class NotificationD2RepositoryTest {
     }
 
     @Test
-    fun `Should not sync notifications with any invalid receivers receivers and for specific user`()  = runBlocking{
-        val notifications = listOf(
-            givenANotification(
-                wildcard = "WEB|iOS|PALM",
-                users = listOf(Ref(id = user.uid(), name = null))
-            )
-        )
-
-        val repository = givenTestData(user, notifications, UserGroups(userGroups = listOf()))
-
-        repository.sync().first()
-
-        verify(basicPreferenceProvider).saveAsJson(
-            NOTIFICATIONS,
-            emptyList<Notification>(),
-        )
-    }
-
-    @Test
-    fun `Should not sync notifications with any not valid receivers and for specific userGroup`()  = runBlocking{
-        val notifications = listOf(
-            givenANotification(
-                wildcard = "WEB|iOS|PALM",
-                userGroups = arrayListOf(Ref(id = "userGroup1", name = null))
-            )
-        )
-
-        val repository = givenTestData(
-            user,
-            notifications,
-            UserGroups(userGroups = listOf(Ref(id = "userGroup1", name = null)))
-        )
-
-        repository.sync().first()
-
-        verify(basicPreferenceProvider).saveAsJson(
-            NOTIFICATIONS,
-            emptyList<Notification>(),
-        )
-    }
-
-    @Test
     fun `Should not sync notifications with web receivers and for specific user`() = runBlocking {
         val notifications = listOf(
             givenANotification(


### PR DESCRIPTION
✏️ Description:
Support wildcard format like =  "ALL|Web|Android|Both" when we only support ALL, ANDROID, or BOTH separately 

📌 References
Issue: https://app.clickup.com/t/8698xxr71

⚙️ branches
app: android-capture-app
Origin: [develop-widp](https://github.com/EyeSeeTea/dhis2-android-capture-app/tree/develop-widp)
Target: [feature/WIDP_Wildcard_implementation](https://github.com/EyeSeeTea/dhis2-android-capture-app/tree/feature/WIDP_Wildcard_implementation)

dhis2-android-SDK:
Origin: develop-eyeseetea

🎩 What is the goal?
When we get the Notifications list with a wildcard like =  "ALL|Web|Android|Both", we should save/show valid notifications by platform.
Valid formats for Android:
ALL
Both
Android
ALL|Android|Both
Android|Both
ALL|Both
Android|ALL

📝 How is it being implemented?
I've included more cases in the current Notifications repository

💾 Requires DB migration?
[X] Nope, we can just merge this branch.
[ ] Yes, but we need to apply it before merging this branch.
[ ] Yes, it's already applied.
🎨 UI changes?
[X] Nope, the UI remains as beautiful as it was before!
[ ] Yeap, here you have some screenshots-
📲Which Android versions did you test this issue?
[X] 11.X - 13.X