### PR TITLE
[Simprints] Auto verify and navigate to TEI after biometric search using cardID

### DIFF
--- a/app/src/androidTest/java/org/dhis2/common/db/TestingDatabase.kt
+++ b/app/src/androidTest/java/org/dhis2/common/db/TestingDatabase.kt
@@ -30,7 +30,7 @@ class TestingDatabase : BaseTest() {
         /* Download db */
         val d2 = D2Manager.blockingInstantiateD2(ServerModule.getD2Configuration(ApplicationProvider.getApplicationContext<AppTest>()))
         d2?.userModule()
-            ?.logIn(username, password, url)
+            ?.logIn(username, password, url, null)
             ?.blockingGet()
         d2?.metadataModule()?.blockingDownload()
 

--- a/app/src/main/java/org/dhis2/data/biometrics/BiometricsClient.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/BiometricsClient.kt
@@ -55,6 +55,8 @@ sealed class VerifyResult {
     data object AgeGroupNotSupported : VerifyResult()
 }
 
+// TODO: this constant should be in the simprints library.
+// Review future versions of the library to see if this is still needed
 const val SIMPRINTS_SEARCH_VERIFY_MATCHED = "searchAndVerifyMatched"
 
 class BiometricsClient(

--- a/app/src/main/java/org/dhis2/data/biometrics/BiometricsClient.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/BiometricsClient.kt
@@ -55,6 +55,8 @@ sealed class VerifyResult {
     data object AgeGroupNotSupported : VerifyResult()
 }
 
+const val SIMPRINTS_SEARCH_VERIFY_MATCHED = "searchAndVerifyMatched"
+
 class BiometricsClient(
     projectId: String,
     user: String,
@@ -287,32 +289,31 @@ class BiometricsClient(
                 IdentifyResult.UserNotFound(sessionId)
             } else {
 
+                val searchAndVerifyMatched = data.getBooleanExtra(SIMPRINTS_SEARCH_VERIFY_MATCHED,false)
                 //TODO: Review Remove this hardcoded solution
                 val identification = identifications.firstOrNull()
 
-                if (identification != null) {
-
+                if (identification != null && searchAndVerifyMatched) {
                     IdentifyResult.CompletedByCardID( SimprintsItem(
                         identification.guid,
                         identification.confidence
                     ), sessionId)
                 } else {
-                    IdentifyResult.UserNotFound(sessionId)
-                }
-                /*                val finalIdentifications =
-                                    identifications.filter { it.confidence >= confidenceScoreFilter }
+                    val finalIdentifications =
+                        identifications.filter { it.confidence >= confidenceScoreFilter }
 
-                                if (finalIdentifications.isEmpty()) {
-                                    Timber.w("Identify returns data but no match with confidence score filter")
-                                    IdentifyResult.UserNotFound(sessionId)
-                                } else {
-                                    IdentifyResult.Completed(finalIdentifications.map {
-                                        SimprintsItem(
-                                            it.guid,
-                                            it.confidence
-                                        )
-                                    }, sessionId)
-                                }*/
+                    if (finalIdentifications.isEmpty()) {
+                        Timber.w("Identify returns data but no match with confidence score filter")
+                        IdentifyResult.UserNotFound(sessionId)
+                    } else {
+                        IdentifyResult.Completed(finalIdentifications.map {
+                            SimprintsItem(
+                                it.guid,
+                                it.confidence
+                            )
+                        }, sessionId)
+                    }
+                }
             }
         } else {
             return IdentifyResult.Failure

--- a/app/src/main/java/org/dhis2/data/biometrics/BiometricsClient.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/BiometricsClient.kt
@@ -40,6 +40,7 @@ data class SimprintsItem(
 
 sealed class IdentifyResult {
     data class Completed(val items: List<SimprintsItem>, val sessionId: String) : IdentifyResult()
+    data class CompletedByCardID(val item: SimprintsItem, val sessionId: String) : IdentifyResult()
     data object BiometricsDeclined : IdentifyResult()
     data class UserNotFound(val sessionId: String) : IdentifyResult()
     data object Failure : IdentifyResult()
@@ -211,7 +212,13 @@ class BiometricsClient(
                         identifyResponse.sessionId
                     )
                 }
-
+                is IdentifyResult.CompletedByCardID -> {
+                    Timber.d("Possible duplicate: ${identifyResponse.item}")
+                    RegisterResult.PossibleDuplicates(
+                        listOf(identifyResponse.item),
+                        identifyResponse.sessionId
+                    )
+                }
                 is IdentifyResult.BiometricsDeclined -> {
                     RegisterResult.Failure
                 }
@@ -279,20 +286,33 @@ class BiometricsClient(
             } else if (identifications.isNullOrEmpty()) {
                 IdentifyResult.UserNotFound(sessionId)
             } else {
-                val finalIdentifications =
-                    identifications.filter { it.confidence >= confidenceScoreFilter }
 
-                if (finalIdentifications.isEmpty()) {
-                    Timber.w("Identify returns data but no match with confidence score filter")
-                    IdentifyResult.UserNotFound(sessionId)
+                //TODO: Review Remove this hardcoded solution
+                val identification = identifications.firstOrNull()
+
+                if (identification != null) {
+
+                    IdentifyResult.CompletedByCardID( SimprintsItem(
+                        identification.guid,
+                        identification.confidence
+                    ), sessionId)
                 } else {
-                    IdentifyResult.Completed(finalIdentifications.map {
-                        SimprintsItem(
-                            it.guid,
-                            it.confidence
-                        )
-                    }, sessionId)
+                    IdentifyResult.UserNotFound(sessionId)
                 }
+                /*                val finalIdentifications =
+                                    identifications.filter { it.confidence >= confidenceScoreFilter }
+
+                                if (finalIdentifications.isEmpty()) {
+                                    Timber.w("Identify returns data but no match with confidence score filter")
+                                    IdentifyResult.UserNotFound(sessionId)
+                                } else {
+                                    IdentifyResult.Completed(finalIdentifications.map {
+                                        SimprintsItem(
+                                            it.guid,
+                                            it.confidence
+                                        )
+                                    }, sessionId)
+                                }*/
             }
         } else {
             return IdentifyResult.Failure

--- a/app/src/main/java/org/dhis2/usescases/biometrics/ui/SequentialSearch.kt
+++ b/app/src/main/java/org/dhis2/usescases/biometrics/ui/SequentialSearch.kt
@@ -54,6 +54,7 @@ sealed class SequentialSearch(
         val biometricUid: String,
         val sessionId: String?,
         val isAgeNotSupported: Boolean,
+        val useCardID: Boolean
     ) : SequentialSearch(previousSearch, nextActions)
 
     data class AttributeSearch(

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.kt
@@ -597,8 +597,10 @@ class SearchTEActivity : ActivityGlobalAbstract(), SearchTEContractsModule.View 
                 when (legacyInteraction.id) {
                     LegacyInteractionID.ON_ENROLL_CLICK -> {
                         val interaction = legacyInteraction as OnEnrollClick
-                        presenter.onEnrollClick(HashMap(interaction.queryData),
-                            viewModel.sequentialSearch.value)
+                        presenter.onEnrollClick(
+                            HashMap(interaction.queryData),
+                            viewModel.sequentialSearch.value
+                        )
                     }
 
                     LegacyInteractionID.ON_ADD_RELATIONSHIP -> {
@@ -633,6 +635,7 @@ class SearchTEActivity : ActivityGlobalAbstract(), SearchTEContractsModule.View 
                             interaction.online,
                         )*/
                     }
+
                     LegacyInteractionID.ON_SEARCH_TEI_MODEL_CLICK -> {
                         val interaction = legacyInteraction as OnSearchTeiModelClick
                         presenter.onSearchTEIModelClick(
@@ -807,7 +810,12 @@ class SearchTEActivity : ActivityGlobalAbstract(), SearchTEContractsModule.View 
         }
     }
 
-    override fun openDashboard(teiUid: String, programUid: String?, enrollmentUid: String?, sessionId: String?) {
+    override fun openDashboard(
+        teiUid: String,
+        programUid: String?,
+        enrollmentUid: String?,
+        sessionId: String?
+    ) {
         searchNavigator.openDashboard(teiUid, programUid, enrollmentUid, sessionId)
         viewModel.resetSequentialSearch()
         viewModel.clearQueryData()
@@ -872,16 +880,28 @@ class SearchTEActivity : ActivityGlobalAbstract(), SearchTEContractsModule.View 
     }
 
     override fun sendBiometricsConfirmIdentity(
-        sessionId: String, guid: String, teiUid: String,
-        enrollmentUid: String, isOnline: Boolean
+        sessionId: String, guid: String, teiUid: String
     ) {
-        if (lastSelection != null) {
-            BiometricsClientFactory.get(this).confirmIdentify(
-                this,
-                sessionId, guid, lastSelection!!.tei.uid()
-            )
-            viewModel.clearQueryData()
-        }
+        BiometricsClientFactory.get(this).confirmIdentify(
+            this,
+            sessionId, guid, teiUid
+        )
+        viewModel.clearQueryData()
+    }
+
+    override fun sendAutomaticBiometricsConfirmIdentity(
+        sessionId: String,
+        guid: String,
+        item: SearchTeiModel
+    ) {
+        viewModel.resetSequentialSearch()
+        lastSelection = item
+
+        BiometricsClientFactory.get(this).confirmIdentify(
+            this,
+            sessionId, guid, item.tei.uid()
+        )
+        viewModel.clearQueryData()
     }
 
     public override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -896,8 +916,14 @@ class SearchTEActivity : ActivityGlobalAbstract(), SearchTEContractsModule.View 
 
                     presenter.searchOnBiometrics(
                         completedResult.items,
-                        completedResult.sessionId, false
+                        completedResult.sessionId, false, false
                     )
+                } else if (result is IdentifyResult.CompletedByCardID) {
+                    presenter.searchOnBiometrics(
+                        listOf(result.item),
+                        result.sessionId, false, true
+                    )
+
                 } else if (result is BiometricsDeclined) {
                     Toast.makeText(
                         context, R.string.biometrics_declined,
@@ -946,7 +972,7 @@ class SearchTEActivity : ActivityGlobalAbstract(), SearchTEContractsModule.View 
     private fun simulateNotFoundBiometricsSearch(sessionId: String?) {
         presenter.searchOnBiometrics(
             listOf<SimprintsItem>(SimprintsItem(BIOMETRICS_USER_NOT_FOUND, 0f)),
-            sessionId, false
+            sessionId, false, false
         )
     }
 

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEContractsModule.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEContractsModule.java
@@ -66,10 +66,12 @@ public class SearchTEContractsModule {
 
         void showSyncDialog(String teiUid);
 
-        void sendBiometricsConfirmIdentity(String sessionId, String guid, String teiUid,
-                String enrollmentUid, boolean isOnline);
+        void sendBiometricsConfirmIdentity(String sessionId, String guid, String teiUid);
+
+        void sendAutomaticBiometricsConfirmIdentity(String sessionId, String guid, SearchTeiModel item );
 
         void showBiometricsSearchConfirmation(SearchTeiModel item);
+
         void launchBiometricsIdentify(String moduleId, List<String> userOrgUnits);
     }
 
@@ -90,6 +92,7 @@ public class SearchTEContractsModule {
         void enroll(String programUid, String teiUid, HashMap<String, String> queryData);
 
         void onTEIClick(String teiUid, String enrollmentUid, boolean isOnline);
+
         void onSearchTEIModelClick(SearchTeiModel item, SequentialSearch sequentialSearch);
 
         TrackedEntityType getTrackedEntityName();
@@ -140,13 +143,15 @@ public class SearchTEContractsModule {
 
         void trackSearchMapVisualization();
 
-        void searchOnBiometrics(List <SimprintsItem> simprintsItems, String sessionId, Boolean ageNotSupported);
+        void searchOnBiometrics(List<SimprintsItem> simprintsItems, String sessionId, Boolean ageNotSupported, Boolean useCardID);
 
         boolean getBiometricsSearchStatus();
 
         void setBiometricListener(SearchTEPresenter.BiometricsSearchListener biometricsSearchListener);
 
         void sendBiometricsConfirmIdentity(String teiUid, String enrollmentUid, boolean isOnline);
+
+        void sendAutomaticBiometricsConfirmIdentity(SearchTeiModel item);
 
         String getLastBiometricsSessionId();
 

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEIViewModel.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEIViewModel.kt
@@ -147,7 +147,7 @@ class SearchTEIViewModel(
 
     private val biometricsMode = getBiometricsConfig(basicPreferenceProvider).biometricsMode
 
-    private val _isDataLoaded = MutableLiveData<Boolean?> (false)
+    private val _isDataLoaded = MutableLiveData<Boolean?>(false)
     val isDataLoaded: MutableLiveData<Boolean?> = _isDataLoaded
 
     init {
@@ -162,7 +162,7 @@ class SearchTEIViewModel(
             )
         }
 
-        presenter.setBiometricListener { simprintsItems, biometricAttributeUid, filterValue, sessionId, ageNotSupported ->
+        presenter.setBiometricListener { simprintsItems, biometricAttributeUid, filterValue, sessionId, ageNotSupported, useCardID ->
             val previousSearch = when (sequentialSearch.value) {
                 is SequentialSearch.BiometricsSearch -> null
                 is SequentialSearch.AttributeSearch -> sequentialSearch.value
@@ -181,7 +181,8 @@ class SearchTEIViewModel(
                     isAgeNotSupported = ageNotSupported,
                     biometricUid = filterValue,
                     previousSearch = previousSearch,
-                    nextActions = nextActions
+                    nextActions = nextActions,
+                    useCardID = useCardID,
                 )
             )
 
@@ -255,9 +256,9 @@ class SearchTEIViewModel(
         val displayFrontPageList =
             searchRepository.getProgram(initialProgramUid)?.displayFrontPageList() ?: true
         val shouldOpenSearch = !displayFrontPageList &&
-            !searchRepository.canCreateInProgramWithoutSearch() &&
-            !searching &&
-            _filtersActive.value == false
+                !searchRepository.canCreateInProgramWithoutSearch() &&
+                !searching &&
+                _filtersActive.value == false
 
         createButtonScrollVisibility.postValue(
             if (searching) {
@@ -339,7 +340,7 @@ class SearchTEIViewModel(
         )
     }
 
-    fun setSearchScreen(fromRelationship:Boolean? = null) {
+    fun setSearchScreen(fromRelationship: Boolean? = null) {
         _screenState.postValue(
             SearchList(
                 previousSate = _screenState.value?.screenState ?: SearchScreenState.NONE,
@@ -631,7 +632,9 @@ class SearchTEIViewModel(
 
             _sequentialSearch.postValue(
                 SequentialSearch.AttributeSearch(
-                    previousSearch = previousSearch, nextActions = nextActions, queryData = queryData.toMap()
+                    previousSearch = previousSearch,
+                    nextActions = nextActions,
+                    queryData = queryData.toMap()
                 )
             )
         }
@@ -1224,10 +1227,6 @@ class SearchTEIViewModel(
 
 
     // EyeSeeTea customization
-    fun getBiometricsSearchStatus(): Boolean {
-        return presenter.biometricsSearchStatus
-    }
-
     fun openSearchForm() {
         _screenState.value.takeIf { it is SearchList }?.let {
             val currentScreen = (it as SearchList)
@@ -1322,6 +1321,16 @@ class SearchTEIViewModel(
                 message,
             ),
         )
+    }
+
+    fun verifyAutonavigateToTEI(items: List<SearchTeiModel>) {
+        val sequentialSearch = _sequentialSearch.value
+
+        if (items.size == 1 && sequentialSearch is SequentialSearch.BiometricsSearch && sequentialSearch.useCardID) {
+            val item = items.first()
+
+            presenter.sendAutomaticBiometricsConfirmIdentity(item)
+        }
     }
 
 }

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
@@ -394,15 +394,18 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
     @Override
     public void sendBiometricsConfirmIdentity(String teiUid, String enrollmentUid, boolean isOnline) {
         if (sessionId != null) {
-            TrackedEntityInstance tei =
-                    d2.trackedEntityModule().trackedEntityInstances()
-                            .withTrackedEntityAttributeValues().uid(teiUid).blockingGet();
+            String guid = updateBiometricsAttributeValue(teiUid);
 
-            String guid = getBiometricsValueFromTEI(tei);
+            view.sendBiometricsConfirmIdentity(sessionId, guid, teiUid);
+        }
+    }
 
-            searchRepository.updateAttributeValue(teiUid, biometricUid, guid);
+    @Override
+    public void sendAutomaticBiometricsConfirmIdentity(SearchTeiModel item) {
+        if (sessionId != null) {
+            String guid = updateBiometricsAttributeValue(item.uid());
 
-            view.sendBiometricsConfirmIdentity(sessionId, guid, teiUid, enrollmentUid, isOnline);
+            view.sendAutomaticBiometricsConfirmIdentity(sessionId, guid, item);
         }
     }
 
@@ -653,7 +656,7 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
     }
 
     @Override
-    public void searchOnBiometrics(List<SimprintsItem> simprintsItems, String sessionId, Boolean ageNotSupported) {
+    public void searchOnBiometrics(List<SimprintsItem> simprintsItems, String sessionId, Boolean ageNotSupported, Boolean useCardID) {
         if (biometricsSearchListener != null) {
             this.sessionId = sessionId;
             List<String> guids = simprintsItems.stream().map(SimprintsItem::getGuid).collect(Collectors.toList());
@@ -675,7 +678,7 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
 
             biometricsSearchStatus = true;
 
-            biometricsSearchListener.onBiometricsSearch(simprintsItems, biometricUid, sb.toString(), sessionId, ageNotSupported);
+            biometricsSearchListener.onBiometricsSearch(simprintsItems, biometricUid, sb.toString(), sessionId, ageNotSupported, useCardID);
         }
     }
 
@@ -724,6 +727,18 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
     }
 
     public interface BiometricsSearchListener {
-        void onBiometricsSearch(List<SimprintsItem> simprintsItems, String biometricAttributeUid, String filterValue, @Nullable String sessionId, Boolean ageNotSupported);
+        void onBiometricsSearch(List<SimprintsItem> simprintsItems, String biometricAttributeUid, String filterValue, @Nullable String sessionId, Boolean ageNotSupported, Boolean useCardID);
+    }
+
+    private String updateBiometricsAttributeValue(String teiUid) {
+        TrackedEntityInstance tei =
+                d2.trackedEntityModule().trackedEntityInstances()
+                        .withTrackedEntityAttributeValues().uid(teiUid).blockingGet();
+
+        String guid = getBiometricsValueFromTEI(tei);
+
+        searchRepository.updateAttributeValue(teiUid, biometricUid, guid);
+
+        return guid;
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/listView/SearchTEList.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/listView/SearchTEList.kt
@@ -401,6 +401,8 @@ class SearchTEList : FragmentGlobalAbstract() {
                 it?.takeIf { view != null }?.collectLatest {
                     liveAdapter.addOnPagesUpdatedListener {
                         onInitDataLoaded()
+
+                        viewModel.verifyAutonavigateToTEI(liveAdapter.snapshot().items)
                     }
 
                     val pagingData = it.map { searchResult ->

--- a/app/src/test/java/org/dhis2/usescases/biometrics/ui/SequentialSearchTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/biometrics/ui/SequentialSearchTest.kt
@@ -73,7 +73,7 @@ class SequentialSearchTest {
 
     @Test
     fun `Should return query data with biometrics and normal attributes if it's biometrics search and exist previous attributes search`() {
-        val biometricsSearch =givenABiometricsSearch( givenAnAttributeSearch(null))
+        val biometricsSearch = givenABiometricsSearch(givenAnAttributeSearch(null))
 
         val queryData = biometricsSearch.finalQueryData
 
@@ -85,7 +85,7 @@ class SequentialSearchTest {
 
     @Test
     fun `Should return query data with normal attributes if it's failed biometrics search and exist previous attributes search`() {
-        val biometricsSearch =givenAFailedBiometricsSearch( givenAnAttributeSearch(null))
+        val biometricsSearch = givenAFailedBiometricsSearch(givenAnAttributeSearch(null))
 
         val queryData = biometricsSearch.finalQueryData
 
@@ -101,7 +101,8 @@ class SequentialSearchTest {
             nextActions = emptyList(),
             sessionId = sessionId,
             biometricUid = biometricUid,
-            isAgeNotSupported = false
+            isAgeNotSupported = false,
+            useCardID = false
         )
         return biometricsSearch
     }
@@ -112,7 +113,8 @@ class SequentialSearchTest {
             nextActions = emptyList(),
             sessionId = null,
             biometricUid = biometricUid,
-            isAgeNotSupported = false
+            isAgeNotSupported = false,
+            useCardID = false
         )
         return biometricsSearch
     }


### PR DESCRIPTION
This commit use a hardcoded solution in biometrics client, pending to changes in simprints lib

### :pushpin: References
* **Issue:** https://app.clickup.com/t/869902x5p
* **Related Pull request:**

###   :gear: branches 
**app**: 
       Origin:feature-simprints/auto_navigate_verify_after_search_with_card_id  Target: develop-simprints
**dhis2-android-SDK**: 
       Origin: 79239151c4f64e9bab83750c12117314d8fea1f3

### :tophat: What is the goal?

Simprints has implemented a new functionality in the Simprints App to allow multi factor authentication using QR Codes/ID Card Scans. 

For patients who have been authenticated in this manner, for searches using Biometrics, we should consider them auto verified and directly move to the TEI dashboard(with Verified flag) instead of displaying a list of potential matches for the user to select. 

Simprints will implement a flag that will be returned in Simprints call responses to indicate these authenticated patients and DHIS should use this flag to skip the user selection screens and move directly to the TEI dashboard 

### :memo: How is it being implemented?

- [x] Changes in BiometricsClient to return completedByCardId
- [x] Change after search to autoverify and navigate to TEI if it's one result and biometrics search by cardId

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-