### PR TITLE
[WIDP] Fix bug saving in cache after mark as read

### DIFF
--- a/app/src/main/java/org/dhis2/data/notifications/NotificationD2Repository.kt
+++ b/app/src/main/java/org/dhis2/data/notifications/NotificationD2Repository.kt
@@ -4,7 +4,6 @@ import NotificationsApi
 import UserGroupsApi
 import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flow
 import org.dhis2.commons.prefs.BasicPreferenceProvider
 import org.dhis2.commons.prefs.Preference
@@ -26,17 +25,9 @@ class NotificationD2Repository(
         try {
             val allNotifications = getAllNotificationsFromRemote()
 
-            val userGroups = getUserGroups()
-
-            val userNotifications =
-                getNotificationsForCurrentUser(allNotifications, userGroups.userGroups)
-
-            preferenceProvider.saveAsJson(Preference.NOTIFICATIONS, userNotifications)
+            saveUserNotificationsInCache(allNotifications)
 
             emit(Unit)
-
-            Timber.d("Notifications synced")
-            Timber.d("Notifications: $userNotifications")
 
         } catch (e: Exception) {
             Timber.e(e)
@@ -75,12 +66,14 @@ class NotificationD2Repository(
 
             notificationsApi.postData(notifications)
 
+            saveUserNotificationsInCache(notifications)
+
             emit(Unit)
 
         }catch (e: Exception){
             Timber.e("Error updating notifications: $e")
         }
-    }.flatMapConcat { sync() }
+    }
 
     private suspend fun getAllNotificationsFromRemote(): List<Notification> {
         try {
@@ -89,6 +82,18 @@ class NotificationD2Repository(
             Timber.e("Error getting notifications: $e")
             return emptyList()
         }
+    }
+
+    private suspend fun saveUserNotificationsInCache(allNotifications: List<Notification>) {
+        val userGroups = getUserGroups()
+
+        val userNotifications =
+            getNotificationsForCurrentUser(allNotifications, userGroups.userGroups)
+
+        preferenceProvider.saveAsJson(Preference.NOTIFICATIONS, userNotifications)
+
+        Timber.d("Notifications saved in cache")
+        Timber.d("Notifications: $userNotifications")
     }
 
     private suspend fun getUserGroups(): UserGroups {

--- a/app/src/main/java/org/dhis2/data/notifications/NotificationD2Repository.kt
+++ b/app/src/main/java/org/dhis2/data/notifications/NotificationD2Repository.kt
@@ -98,8 +98,7 @@ class NotificationD2Repository(
 
     private suspend fun getUserGroups(): UserGroups {
         try {
-            return userGroupsApi
-                .getData(d2.userModule().user().blockingGet()!!.uid())
+            return userGroupsApi.getData()
         } catch (e: Exception) {
             Timber.e("Error getting userGroups: $e")
             return UserGroups(listOf())

--- a/app/src/main/java/org/dhis2/data/notifications/NotificationsApi.kt
+++ b/app/src/main/java/org/dhis2/data/notifications/NotificationsApi.kt
@@ -1,7 +1,7 @@
+
 import org.dhis2.usescases.notifications.domain.Notification
 import org.dhis2.usescases.notifications.domain.UserGroups
 import org.hisp.dhis.android.core.arch.api.HttpServiceClient
-import org.hisp.dhis.android.core.user.User
 
 class NotificationsApi (private val client: HttpServiceClient) {
     suspend fun getData(): List<Notification>{
@@ -10,7 +10,7 @@ class NotificationsApi (private val client: HttpServiceClient) {
         }
     }
 
-    suspend fun postData( notifications:List<Notification>): User {
+    suspend fun postData( notifications:List<Notification>) {
         return client.put {
             url("dataStore/notifications/notifications")
             body(notifications)

--- a/app/src/main/java/org/dhis2/data/notifications/NotificationsApi.kt
+++ b/app/src/main/java/org/dhis2/data/notifications/NotificationsApi.kt
@@ -19,9 +19,9 @@ class NotificationsApi (private val client: HttpServiceClient) {
 }
 
 class UserGroupsApi (private val client: HttpServiceClient) {
-    suspend fun getData( userId:String): UserGroups {
+    suspend fun getData(): UserGroups {
         return client.get {
-            url("users/$userId?fields=userGroups")
+            url("me?fields=userGroups")
         }
     }
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/869973qae 869973qae
* **Related Pull request:** 


###   :gear: branches 
**app**: 
       Origin: fix-widp/bug_saving_cache_after_mark_as_read Target: develop-widp
**dhis2-android-SDK**: 
       Origin:develop-eyeseetea

### :tophat: What is the goal?

Bug in notifications readBy. Every time you go outside from Settings, a new notification is printed. Probably an issue with backwards compatibility

### :memo: How is it being implemented?

- [x] Fix bug saving in cache after mark as read

### :boom: How can it be tested?

When a notification is marked as read then it should not appear again after navigate to settings and navigate to home again

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-