### PR TITLE
[WIDP] Implement notification translations

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/general/ActivityGlobalAbstract.java
+++ b/app/src/main/java/org/dhis2/usescases/general/ActivityGlobalAbstract.java
@@ -41,6 +41,8 @@ import org.dhis2.utils.analytics.AnalyticsHelper;
 import org.dhis2.utils.granularsync.SyncStatusDialog;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.Timer;
 
 import javax.inject.Inject;
 
@@ -48,6 +50,7 @@ import io.noties.markwon.Markwon;
 import io.reactivex.Observable;
 import io.reactivex.subjects.BehaviorSubject;
 import kotlin.Unit;
+import timber.log.Timber;
 
 
 public abstract class ActivityGlobalAbstract extends SessionManagerActivity
@@ -246,8 +249,9 @@ public abstract class ActivityGlobalAbstract extends SessionManagerActivity
     }
 
     private void showNotification(Notification notification) {
-        Markwon markwon = Markwon.create(getContext());
-        String content = String.valueOf(markwon.toMarkdown(notification.getContent()));
+
+
+        String content = getNotificationContent(notification);
 
         new MaterialAlertDialogBuilder(this, R.style.DhisMaterialDialog)
                 .setTitle("Notification")
@@ -257,5 +261,17 @@ public abstract class ActivityGlobalAbstract extends SessionManagerActivity
                 })
                 .setCancelable(true)
                 .show();
+    }
+
+    private String getNotificationContent(Notification notification) {
+        Markwon markwon = Markwon.create(getContext());
+
+        String language = Locale.getDefault().getLanguage();
+
+        if (notification.getTranslations() != null && notification.getTranslations().containsKey(language)) {
+            return String.valueOf(markwon.toMarkdown(notification.getTranslations().get(language)));
+        } else  {
+            return String.valueOf(markwon.toMarkdown(String.valueOf(markwon.toMarkdown(notification.getContent()))));
+        }
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/notifications/domain/Notification.kt
+++ b/app/src/main/java/org/dhis2/usescases/notifications/domain/Notification.kt
@@ -9,6 +9,7 @@ data class Notification(
     val readBy: List<ReadBy>,
     val recipients: Recipients,
     val permissions: Permissions?,
+    val translations: Map<String, String>?
 )
 
 data class ReadBy(


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/86997d0vc 86997d0vc
* **Related Pull request:** 


###   :gear: branches 
**app**: 
       Origin: feature-widp/notification_translations  Target: fix-widp/bug_saving_cache_after_mark_as_read
**dhis2-android-SDK**: 
       Origin:develop-eyeseetea

### :tophat: What is the goal?

Support new prop translations

### :memo: How is it being implemented?

- [x] modify model
- [x] read if exists translations to show message in expected language

### :boom: How can it be tested?

Change the language for the user in dhis2, restart the app and the notification should appear in expected language if the translation is defined. In case it's not defined show in default.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-