### PR TITLE
[Simprints] Use default button to register new patient

### DIFF
--- a/app/src/main/res/layout/fragment_search_list.xml
+++ b/app/src/main/res/layout/fragment_search_list.xml
@@ -12,9 +12,9 @@
         <com.google.android.material.appbar.AppBarLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
             app:elevation="0dp"
-            app:liftOnScroll="false"
-            android:background="@android:color/transparent">
+            app:liftOnScroll="false">
 
             <androidx.compose.ui.platform.ComposeView
                 android:id="@+id/openSearchButton"
@@ -23,7 +23,7 @@
                 android:clipToPadding="false"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"/>
+                app:layout_constraintTop_toTopOf="parent" />
 
         </com.google.android.material.appbar.AppBarLayout>
 
@@ -42,10 +42,19 @@
             android:id="@+id/createButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:paddingTop="100dp"
+            android:layout_gravity="bottom|end"
+            android:layout_marginBottom="56dp"
             android:clipToPadding="false"
+            android:padding="16dp" />
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/nextActions"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:clipToPadding="false"
+            android:paddingTop="200dp"
             app:layout_anchor="@id/scrollView"
-            app:layout_anchorGravity="bottom|center_horizontal"/>
+            app:layout_anchorGravity="bottom|center_horizontal" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/8699qb0zx #8699qb0zx
* **Related Pull request:**

###   :gear: branches 
**app**: 
       Origin: feature-simprints/use_default_button_to_register_new_patient Target: develop-simprints
**dhis2-android-SDK**: 
       Origin: 79239151c4f64e9bab83750c12117314d8fea1f3

### :tophat: What is the goal?

The Register new patient button is overlapping with the Search results making it unreadable and difficult to click. 

Use default dhis 2 button

### :memo: How is it being implemented?

- [x] Use dhis2 default button

### :boom: How can it be tested?

1 - Enter in general registration
2 - Click on search
3 - Cancel biometrics search o failed by non installed SID app is ok
4 - Search by attributes
5 - It should appear default float button to create a new patient


### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

Previously
<img width="277" height="600" alt="previously1" src="https://github.com/user-attachments/assets/9b8d0591-60d3-4722-9b4a-89bb320d50b7" />


Now
<img width="277" height="600" alt="now2" src="https://github.com/user-attachments/assets/a3132588-ec80-46d4-af5a-f2a186f15620" />


