### PR TITLE
Fix landscape TEI verification view

### DIFF
--- a/app/src/main/res/layout-land/fragment_tei_data.xml
+++ b/app/src/main/res/layout-land/fragment_tei_data.xml
@@ -88,7 +88,7 @@
                     android:padding="42dp"
                     android:text="@string/empty_tei_event_label_add"
                     android:textSize="@dimen/primaryTextSize"
-                    android:visibility="visible"
+                    android:visibility="gone"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## Summary
- match the visibility of the empty TEI view in landscape with the portrait layout so biometrics verification flag is visible

## Testing
- `./gradlew test --dry-run` *(fails: blocked network access)*

------
https://chatgpt.com/codex/tasks/task_b_68820ff1ea68832eb35545289d6df016