### PR TITLE
[SPIP] Mark as non editable event if data to assign in program rule is null

### DIFF
--- a/form/src/main/java/org/dhis2/form/data/RulesUtilsProviderImpl.kt
+++ b/form/src/main/java/org/dhis2/form/data/RulesUtilsProviderImpl.kt
@@ -334,7 +334,8 @@ class RulesUtilsProviderImpl(
                     ruleEffect.data
                 }
 
-            ruleEffect.data?.formatData(field.valueType)?.let { formattedValue ->
+            // EyeSeeTea customization: mark field as non-editable when assigned by a rule even value to assign is null
+/*            ruleEffect.data?.formatData(field.valueType)?.let { formattedValue ->
                 val updatedField = fieldViewModels[assign.field()]
                     ?.setValue(formattedValue)
                     ?.setDisplayName(valueToShow?.formatData(field.valueType))
@@ -343,7 +344,29 @@ class RulesUtilsProviderImpl(
                 updatedField?.let {
                     fieldViewModels[fieldUid] = it
                 }
+            }*/
+
+            if ( ruleEffect.data == null)  {
+                    val updatedField = fieldViewModels[assign.field()]
+                        ?.setValue(ruleEffect.data)
+                        ?.setEditable(false)
+
+                    updatedField?.let {
+                        fieldViewModels[fieldUid] = it
+                    }
+            }else {
+                ruleEffect.data?.formatData(field.valueType)?.let { formattedValue ->
+                    val updatedField = fieldViewModels[assign.field()]
+                        ?.setValue(formattedValue)
+                        ?.setDisplayName(valueToShow?.formatData(field.valueType))
+                        ?.setEditable(false)
+
+                    updatedField?.let {
+                        fieldViewModels[fieldUid] = it
+                    }
+                }
             }
+
         } ?: {
             if (!hiddenFields.contains(assign.field())) {
                 valuesToChange[fieldUid] = ruleEffect.data?.formatData()


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/869a7g1u2 #869a7g1u2
* **Related Pull request:** 

###   :gear: branches 
**app**: 
       Origin: feature-spip/set_non_editable_field_assigned_null_bu_program_rule Target: feature-spip/bring_last_changes_3_1_0_1
**dhis2-android-SDK**: 
       Origin: 79239151c4f64e9bab83750c12117314d8fea1f3

### :tophat: What is the goal?

CHP - Issue with Yes Only fields on Android

### :memo: How is it being implemented?

- [x] [Mark as non editable event if data to assign in program rule is null](https://github.com/EyeSeeTea/dhis2-android-capture-app/commit/391a71d84c6303df1d28bf20296ccf395edb511f)

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-