### PR TITLE
[Simprints] Fix match by credential

### DIFF
--- a/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/BiometricsClient.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/BiometricsClient.kt
@@ -284,7 +284,8 @@ class BiometricsClient(
                 IdentifyResult.UserNotFound(sessionId)
             } else {
                 val finalIdentifications =
-                    identifications.filter { it.confidence >= confidenceScoreFilter }
+                    identifications.filter { it.confidence >= confidenceScoreFilter && !it.isLinkedToCredential } +
+                            identifications.filter {  it.isLinkedToCredential }
 
                 if (finalIdentifications.isEmpty()) {
                     Timber.w("Identify returns data but no match with confidence score filter")

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEContractsModule.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEContractsModule.java
@@ -148,7 +148,7 @@ public class SearchTEContractsModule {
 
         void setBiometricListener(SearchTEPresenter.BiometricsSearchListener biometricsSearchListener);
 
-        void sendBiometricsConfirmIdentity(String teiUid, String enrollmentUid, boolean isOnline);
+        void sendBiometricsConfirmIdentity(String teiUid, String enrollmentUid, boolean isOnline, boolean isMatchByCredentials);
 
         void sendAutomaticBiometricsConfirmIdentity(SearchTeiModel item);
 

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
@@ -394,9 +394,13 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
     }
 
     @Override
-    public void sendBiometricsConfirmIdentity(String teiUid, String enrollmentUid, boolean isOnline) {
+    public void sendBiometricsConfirmIdentity(String teiUid, String enrollmentUid, boolean isOnline, boolean isMatchByCredentials) {
         if (sessionId != null) {
-            String guid = updateBiometricsAttributeValue(teiUid);
+            String guid = getBiometricsAttributeValue(teiUid);
+
+            if (!isMatchByCredentials) {
+                searchRepository.updateAttributeValue(teiUid, biometricAttributeId, guid);
+            }
 
             view.sendBiometricsConfirmIdentity(sessionId, guid, teiUid);
         }
@@ -405,7 +409,9 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
     @Override
     public void sendAutomaticBiometricsConfirmIdentity(SearchTeiModel item) {
         if (sessionId != null) {
-            String guid = updateBiometricsAttributeValue(item.uid());
+            String guid = getBiometricsAttributeValue(item.uid());
+
+            searchRepository.updateAttributeValue(item.uid(), biometricAttributeId, guid);
 
             view.sendAutomaticBiometricsConfirmIdentity(sessionId, guid, item);
         }
@@ -730,14 +736,12 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
         void onBiometricsSearch(List<SimprintsIdentifiedItem> simprintsIdentifiedItems, String biometricAttributeUid, List<SimprintsIdentifiedItem> items, @Nullable String sessionId, Boolean ageNotSupported);
     }
 
-    private String updateBiometricsAttributeValue(String teiUid) {
+    private String getBiometricsAttributeValue(String teiUid) {
         TrackedEntityInstance tei =
                 d2.trackedEntityModule().trackedEntityInstances()
                         .withTrackedEntityAttributeValues().uid(teiUid).blockingGet();
 
         String guid = getBiometricsValueFromTEI(tei);
-
-        searchRepository.updateAttributeValue(teiUid, biometricAttributeId, guid);
 
         return guid;
     }


### PR DESCRIPTION
### :pushpin: References

* **Issue:** https://app.clickup.com/t/869b99zpt #869b99zpt

* **Related Pull request:**

###   :gear: branches 

**app**:  Origin:feature-spip/beneficiary_hub Target: develop-spip

**dhis2-android-SDK**:  

Origin: develop-eyeseetea

### :tophat: What is the goal?

Scenario: 
Biometric Search is done using both Biometrics + NHIS Card. There is no biometric match but there is a NHIS card match. 

Current Behaviour : No results displayed and user is prompted to continue with Demographic Search.

Expected behaviour : Display the results where NHIS number is a match. Allow user to confirm the record (NOTE: if biometrics is not matched, then when redirecting to the TEI dashboard, it should display the  "Verification Failed" flag) 

### :memo: How is it being implemented?

- [x] Fix match by credential
- [x] Fix verified status TEI if match is by credencial

### :boom: How can it be tested?

- Biometric Search is done using both Biometrics + NHIS Card. There is no biometric match but there is a NHIS card match. 
- It should display the results where NHIS number is a match.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-


