### PR TITLE
[SPIP] Avoid ARN to load TEI dashboard

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/DashboardRepositoryImpl.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/DashboardRepositoryImpl.kt
@@ -569,8 +569,13 @@ class DashboardRepositoryImpl(
             val hasProgramIndicator =
                 !d2.programModule().programIndicators().byProgramUid().eq(programUid)
                     .blockingIsEmpty()
-            val hasCharts =
+            // EyeSeeTea customization: check if enrollment has charts without loading them all
+            /* val hasCharts =
                 enrollmentUid?.let { charts.geEnrollmentCharts(enrollmentUid).isNotEmpty() }
+                    ?: false*/
+
+            val hasCharts =
+                enrollmentUid?.let { charts.existsEnrollmentCharts(enrollmentUid) }
                     ?: false
             hasDisplayRuleActions || hasProgramIndicator || hasCharts
         } else {

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/DashboardViewModel.kt
@@ -92,6 +92,10 @@ class DashboardViewModel(
             val result = async {
                 repository.getDashboardModel()
             }
+
+            // EyeSeeTea customization - Avoid ARN reading from database in UI Thread
+            val enrollmentItems = loadNavigationBarItems()
+
             withContext(dispatcher.ui()) {
                 try {
                     val model = result.await()
@@ -105,7 +109,15 @@ class DashboardViewModel(
                         _state.value =
                             model.currentEnrollment.aggregatedSyncState()
                         _noEnrollmentSelected.value = false
-                        loadNavigationBarItems()
+
+                        // EyeSeeTea customization - Avoid ARN reading from database in UI Thread
+                        //loadNavigationBarItems()
+
+                        _navigationBarUIState.value = _navigationBarUIState.value.copy(items = enrollmentItems)
+
+                        if (navigationBarUIState.value.items.none { it.id == navigationBarUIState.value.selectedItem }) {
+                            onNavigationItemSelected(navigationBarUIState.value.items.first().id)
+                        }
                     } else {
                         _noEnrollmentSelected.value = true
                     }
@@ -116,7 +128,7 @@ class DashboardViewModel(
         }
     }
 
-    private fun loadNavigationBarItems() {
+    private fun loadNavigationBarItems(): List<NavigationBarItem<TEIDashboardItems>> {
         val enrollmentItems = mutableListOf<NavigationBarItem<TEIDashboardItems>>()
 
         if (isPortrait()) {
@@ -164,11 +176,14 @@ class DashboardViewModel(
             )
         }
 
-        _navigationBarUIState.value = _navigationBarUIState.value.copy(items = enrollmentItems)
+        // EyeSeeTea customization - Avoid ARN reading from database in UI Thread
+/*        _navigationBarUIState.value = _navigationBarUIState.value.copy(items = enrollmentItems)
 
         if (navigationBarUIState.value.items.none { it.id == navigationBarUIState.value.selectedItem }) {
             onNavigationItemSelected(navigationBarUIState.value.items.first().id)
-        }
+        }*/
+
+        return enrollmentItems
     }
 
     private fun fetchGrouping() {

--- a/commons/src/main/java/org/dhis2/commons/date/CustomDateTransformation.kt
+++ b/commons/src/main/java/org/dhis2/commons/date/CustomDateTransformation.kt
@@ -20,7 +20,9 @@ class CustomDateTransformation : DateTimeVisualTransformation {
     }
 
     private fun dateFilter(text: AnnotatedString): TransformedText {
-        val input = if (text.text.length > DATE_MASK.length) text.text.substring(0, 8) else text.text
+        val originalLength = text.text.length
+
+        val input = if (originalLength > DATE_MASK.length) text.text.substring(0, 8) else text.text
 
         val day = input.take(2).padEnd(2, 'D')
         val month = input.drop(2).take(2).padEnd(2, 'M')
@@ -39,12 +41,16 @@ class CustomDateTransformation : DateTimeVisualTransformation {
             }
 
             override fun transformedToOriginal(offset: Int): Int {
-                return when (offset) {
+                val calculatedOffset = when (offset) {
                     in 0..3 -> offset + 4
+                    4 -> offset
                     in 5..6 -> offset - 3
+                    7 -> offset - 6
                     in 8..9 -> offset - 8
                     else -> 0
                 }
+
+                return if (calculatedOffset > originalLength) originalLength else calculatedOffset
             }
         }
 

--- a/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/Charts.kt
+++ b/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/Charts.kt
@@ -16,6 +16,8 @@ interface Charts {
 
     fun getVisualizationGroups(uid: String?): List<AnalyticsDhisVisualizationsGroup>
 
+    fun existsEnrollmentCharts(enrollmentUid: String): Boolean
+
     fun geEnrollmentCharts(enrollmentUid: String): List<Graph>
 
     fun getProgramVisualizations(groupUid: String?, programUid: String): List<Graph>

--- a/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/ChartsRepository.kt
+++ b/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/ChartsRepository.kt
@@ -30,4 +30,7 @@ interface ChartsRepository {
         columnIndex: Int,
         filterValue: String?,
     )
+
+    // EyeSeeTea customization - know if there are analytics for enrollment without loading them all
+    fun existsAnalyticsForEnrollment(enrollmentUid: String): Boolean
 }

--- a/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/ChartsRepositoryImpl.kt
+++ b/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/ChartsRepositoryImpl.kt
@@ -41,6 +41,52 @@ class ChartsRepositoryImpl(
 
     private val lineListHeaderCache: MutableMap<String, List<TrackerLineListItem>> = mutableMapOf()
 
+    // EyeSeeTea customization - know if there are analytics for enrollment without loading them all
+    override fun existsAnalyticsForEnrollment(enrollmentUid: String): Boolean {
+        val enrollment = getEnrollment(enrollmentUid)
+        if (enrollment?.trackedEntityInstance() == null) return false
+
+        val hasSettingsAnalytics = !d2.settingModule().analyticsSetting().teis()
+            .byProgram().eq(enrollment.program())
+            .blockingIsEmpty()
+
+        if (hasSettingsAnalytics) {
+            return true
+        }
+
+        val repeatableStages = getRepeatableProgramStages(enrollment.program())
+        if (repeatableStages.isEmpty()) {
+            return false
+        }
+
+        val hasIndicators = !d2.programModule().programIndicators()
+            .byDisplayInForm().isTrue
+            .byProgramUid().eq(enrollment.program())
+            .blockingIsEmpty()
+
+        if (hasIndicators) {
+            return true
+        }
+
+        val stageUids = repeatableStages.map { it.uid() }
+        val hasDataElements = !d2.programModule().programStageDataElements()
+            .byProgramStage().`in`(stageUids)
+            .blockingIsEmpty()
+
+        if (!hasDataElements) {
+            return false
+        }
+
+        return d2.programModule().programStageDataElements()
+            .byProgramStage().`in`(stageUids)
+            .blockingGet()
+            .any { programStageDataElement ->
+                val dataElementUid = programStageDataElement.dataElement()?.uid() ?: return@any false
+                val dataElement = d2.dataElementModule().dataElements().uid(dataElementUid).blockingGet()
+                dataElement?.valueType()?.isNumeric == true
+            }
+    }
+
     override fun getAnalyticsForEnrollment(enrollmentUid: String): List<Graph> {
         val enrollment = getEnrollment(enrollmentUid)
         if (enrollment?.trackedEntityInstance() == null) return emptyList()

--- a/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/DhisAnalyticCharts.kt
+++ b/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/DhisAnalyticCharts.kt
@@ -19,6 +19,10 @@ class DhisAnalyticCharts @Inject constructor(
         return chartsRepository.getVisualizationGroups(uid)
     }
 
+    override fun existsEnrollmentCharts(enrollmentUid: String): Boolean {
+        return chartsRepository.existsAnalyticsForEnrollment(enrollmentUid)
+    }
+
     override fun geEnrollmentCharts(enrollmentUid: String): List<Graph> {
         return chartsRepository.getAnalyticsForEnrollment(enrollmentUid)
     }


### PR DESCRIPTION
### :pushpin: References

* **Issue:** https://app.clickup.com/t/869b5e309 #869b5e309
* **Related Pull request:**

### :gear: branches

**app:**  
Origin: feature-spip/fix_bug_to_open_tei_dashboard  
Target: develop-spip

**dhis2-android-SDK:**  
Origin: 79239151c4f64e9bab83750c12117314d8fea1f3

### :tophat: What is the goal?

- Prevent ARN (Application Not Responding) when loading the TEI dashboard.
- On @Ramon-Jimenez device this causes a crash.
- On my device it shows an ARN message but eventually loads.

### :memo: How is it being implemented?

#### Figure out the logcat errors related to program rule execution

These program rules are intended for events, but they are also being executed for the enrollment, which triggers logcat errors.  
The program stage must be selected explicitly in the program rule to avoid this:

https://platform-test.samaritanspurse.org/dhis-web-maintenance/index.html#/edit/programSection/programRule/G4DX9w3oOdf  
https://platform-test.samaritanspurse.org/dhis-web-maintenance/index.html#/edit/programSection/programRule/JknoQjlSmau

#### Solving ARN

- [x] Prevent ARN by avoiding `loadNavigationBarItems` in the UI thread.

Loading navigation items requires reading from the database and takes around 6 seconds, so it must be done on the IO thread instead of the UI thread to avoid ARN.

#### Improve performance

Loading navigation items currently takes about 6 seconds because this program contains many indicators.  
Previously, to decide whether to display the analytics tab, all charts were being created, which is unnecessary.  
To load the TEI dashboard we only need to know whether charts exist, not actually generate them.

- [x] Improve performance when loading the TEI dashboard.

### :boom: How can it be tested?

- Enter the TEI dashboard for the program. It should not show an ARN message and it should load faster.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots


### Before
[before.webm](https://github.com/user-attachments/assets/cd0d25c8-6972-4f5f-8d3a-80037262e8b6)


### Now
[now.webm](https://github.com/user-attachments/assets/15b4708e-96b7-496c-96d8-d2f08b60edf5)

