### PR TITLE
[SPIP] Fix crash to type in date field

### DIFF
--- a/commons/src/main/java/org/dhis2/commons/date/CustomDateTransformation.kt
+++ b/commons/src/main/java/org/dhis2/commons/date/CustomDateTransformation.kt
@@ -20,7 +20,9 @@ class CustomDateTransformation : DateTimeVisualTransformation {
     }
 
     private fun dateFilter(text: AnnotatedString): TransformedText {
-        val input = if (text.text.length > DATE_MASK.length) text.text.substring(0, 8) else text.text
+        val originalLength = text.text.length
+
+        val input = if (originalLength > DATE_MASK.length) text.text.substring(0, 8) else text.text
 
         val day = input.take(2).padEnd(2, 'D')
         val month = input.drop(2).take(2).padEnd(2, 'M')
@@ -39,12 +41,16 @@ class CustomDateTransformation : DateTimeVisualTransformation {
             }
 
             override fun transformedToOriginal(offset: Int): Int {
-                return when (offset) {
+                val calculatedOffset = when (offset) {
                     in 0..3 -> offset + 4
+                    4 -> offset
                     in 5..6 -> offset - 3
+                    7 -> offset - 6
                     in 8..9 -> offset - 8
                     else -> 0
                 }
+
+                return if (calculatedOffset > originalLength) originalLength else calculatedOffset
             }
         }
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** https://app.clickup.com/t/869bj97z1 #869bj97z1
* **Related Pull request:**

### :gear: branches

**app:**  
Origin: feature-spip/fix_crash_to_type_in_date_field
Target: develop-spip

**dhis2-android-SDK:**  
Origin: 79239151c4f64e9bab83750c12117314d8fea1f3

### :tophat: What is the goal?

when I create a new registration on Android, and then tap on the birthday, the screen goes blank and I get this stack trace: There is also a video at the bottom. This emulator is running Android 13 if that helps any.

```java.lang.IllegalStateException: OffsetMapping.transformedToOriginal returned invalid mapping: 5 -> 2 is not in range of original text [0, 0]
	at androidx.compose.foundation.text.ValidatingOffsetMapping.transformedToOriginal(ValidatingOffsetMapping.kt:76)
	at androidx.compose.foundation.text.TextFieldDelegate$Companion.setCursorOffset-ULxng0E$foundation_release(TextFieldDelegate.kt:265)
	at androidx.compose.foundation.text.CoreTextFieldKt$CoreTextField$pointerModifier$2.invoke-k-4lQ0M(CoreTextField.kt:378)
	at androidx.compose.foundation.text.CoreTextFieldKt$CoreTextField$pointerModifier$2.invoke(CoreTextField.kt:373)
	at androidx.compose.foundation.text.TextFieldPressGestureFilterKt$tapPressTextFieldModifier$1$2$2.invoke-k-4lQ0M(TextFieldPressGestureFilter.kt:81)
	at androidx.compose.foundation.text.TextFieldPressGestureFilterKt$tapPressTextFieldModifier$1$2$2.invoke(TextFieldPressGestureFilter.kt:54)
	at androidx.compose.foundation.gestures.TapGestureDetectorKt$detectTapAndPress$2$1.invokeSuspend(TapGestureDetector.kt:255)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTaskKt.resume(DispatchedTask.kt:175)
	at kotlinx.coroutines.DispatchedTaskKt.dispatch(DispatchedTask.kt:164)
	at kotlinx.coroutines.CancellableContinuationImpl.dispatchResume(CancellableContinuationImpl.kt:470)
	at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl(CancellableContinuationImpl.kt:504)
	at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl$default(CancellableContinuationImpl.kt:493)
	at kotlinx.coroutines.CancellableContinuationImpl.resumeWith(CancellableContinuationImpl.kt:364)
	at androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNodeImpl$PointerEventHandlerCoroutine.offerPointerEvent(SuspendingPointerInputFilter.kt:665)
	at androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNodeImpl.dispatchPointerEvent(SuspendingPointerInputFilter.kt:544)
	at androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNodeImpl.onPointerEvent-H0pRuoY(SuspendingPointerInputFilter.kt:566)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:317)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:303)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:303)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:303)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:303)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:303)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:303)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:303)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:303)
	at androidx.compose.ui.input.pointer.NodeParent.dispatchMainEventPass(HitPathTracker.kt:185)
	at androidx.compose.ui.input.pointer.HitPathTracker.dispatchChanges(HitPathTracker.kt:104)
	at androidx.compose.ui.input.pointer.PointerInputEventProcessor.process-BIzXfog(PointerInputEventProcessor.kt:113)
	at androidx.compose.ui.platform.AndroidComposeView.sendMotionEvent-8iAsVTc(AndroidComposeView.android.kt:1576)
	at androidx.compose.ui.platform.AndroidComposeView.handleMotionEvent-8iAsVTc(AndroidComposeView.android.kt:1527)
	at androidx.compose.ui.platform.AndroidComposeView.dispatchTouchEvent(AndroidComposeView.android.kt:1466)
	at android.view.ViewGroup.dispatchTransformedTouchEvent([ViewGroup.java:3121](http://viewgroup.java:3121/))
	at android.view.ViewGroup.dispatchTouchEvent([ViewGroup.java:2802](http://viewgroup.java:2802/))
	at android.view.ViewGroup.dispatchTransformedTouchEvent([ViewGroup.java:3121](http://viewgroup.java:3121/))
	at android.view.ViewGroup.dispatchTouchEvent([ViewGroup.java:2802](http://viewgroup.java:2802/))
	at android.view.ViewGroup.dispatchTransformedTouchEvent([ViewGroup.java:3121](http://viewgroup.java:3121/))
	at android.view.ViewGroup.dispatchTouchEvent([ViewGroup.java:2802](http://viewgroup.java:2802/))
	at android.view.ViewGroup.dispatchTransformedTouchEvent([ViewGroup.java:3121](http://viewgroup.java:3121/))
	at android.view.ViewGroup.dispatchTouchEvent([ViewGroup.java:2802](http://viewgroup.java:2802/))
	at android.view.ViewGroup.dispatchTransformedTouchEvent([ViewGroup.java:3121](http://viewgroup.java:3121/))
	at android.view.ViewGroup.dispatchTouchEvent([ViewGroup.java:2802](http://viewgroup.java:2802/))
	at android.view.ViewGroup.dispatchTransformedTouchEvent([ViewGroup.java:3121](http://viewgroup.java:3121/))
	at android.view.ViewGroup.dispatchTouchEvent([ViewGroup.java:2802](http://viewgroup.java:2802/))
	at android.view.ViewGroup.dispatchTransformedTouchEvent([ViewGroup.java:3121](http://viewgroup.java:3121/))
	at android.view.ViewGroup.dispatchTouchEvent([ViewGroup.java:2802](http://viewgroup.java:2802/))
	at android.view.ViewGroup.dispatchTransformedTouchEvent([ViewGroup.java:3121](http://viewgroup.java:3121/))
	at android.view.ViewGroup.dispatchTouchEvent([ViewGroup.java:2802](http://viewgroup.java:2802/))
	at com.android.internal.policy.DecorView.superDispatchTouchEvent([DecorView.java:500](http://decorview.java:500/))
	at com.android.internal.policy.PhoneWindow.superDispatchTouchEvent([PhoneWindow.java:1905](http://phonewindow.java:1905/))
	at android.app.Activity.dispatchTouchEvent([Activity.java:4337](http://activity.java:4337/))
	at androidx.appcompat.view.WindowCallbackWrapper.dispatchTouchEvent([WindowCallbackWrapper.java:70](http://windowcallbackwrapper.java:70/))
	at com.android.internal.policy.DecorView.dispatchTouchEvent([DecorView.java:458](http://decorview.java:458/))
	at android.view.View.dispatchPointerEvent([View.java:15273](http://view.java:15273/))
	at android.view.ViewRootImpl$ViewPostImeInputStage.processPointerEvent([ViewRootImpl.java:6757](http://viewrootimpl.java:6757/))
	at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess([ViewRootImpl.java:6557](http://viewrootimpl.java:6557/))
	at android.view.ViewRootImpl$InputStage.deliver([ViewRootImpl.java:6013](http://viewrootimpl.java:6013/))
	at android.view.ViewRootImpl$InputStage.onDeliverToNext([ViewRootImpl.java:6070](http://viewrootimpl.java:6070/))
	at android.view.ViewRootImpl$InputStage.forward([ViewRootImpl.java:6036](http://viewrootimpl.java:6036/))
	at android.view.ViewRootImpl$AsyncInputStage.forward([ViewRootImpl.java:6201](http://viewrootimpl.java:6201/))
	at android.view.ViewRootImpl$InputStage.apply([ViewRootImpl.java:6044](http://viewrootimpl.java:6044/))
	at android.view.ViewRootImpl$AsyncInputStage.apply([ViewRootImpl.java:6258](http://viewrootimpl.java:6258/))
	at android.view.ViewRootImpl$InputStage.deliver([ViewRootImpl.java:6017](http://viewrootimpl.java:6017/))
	at android.view.ViewRootImpl$InputStage.onDeliverToNext([ViewRootImpl.java:6070](http://viewrootimpl.java:6070/))
	at android.view.ViewRootImpl$InputStage.forward([ViewRootImpl.java:6036](http://viewrootimpl.java:6036/))
	at android.view.ViewRootImpl$InputStage.apply([ViewRootImpl.java:6044](http://viewrootimpl.java:6044/))
	at android.view.ViewRootImpl$InputStage.deliver([ViewRootImpl.java:6017](http://viewrootimpl.java:6017/))
	at android.view.ViewRootImpl.deliverInputEvent([ViewRootImpl.java:9103](http://viewrootimpl.java:9103/))
	at android.view.ViewRootImpl.doProcessInputEvents([ViewRootImpl.java:9054](http://viewrootimpl.java:9054/))
	at android.view.ViewRootImpl.enqueueInputEvent([ViewRootImpl.java:9023](http://viewrootimpl.java:9023/))
	at android.view.ViewRootImpl$WindowInputEventReceiver.onInputEvent([ViewRootImpl.java:9226](http://viewrootimpl.java:9226/))
	at android.view.InputEventReceiver.dispatchInputEvent([InputEventReceiver.java:267](http://inputeventreceiver.java:267/))
	at android.os.MessageQueue.nativePollOnce(Native Method)
	at [android.os.MessageQueue.next](http://android.os.messagequeue.next/)([MessageQueue.java:335](http://messagequeue.java:335/))
	at android.os.Looper.loopOnce([Looper.java:161](http://looper.java:161/))
	at android.os.Looper.loop([Looper.java:288](http://looper.java:288/))
	at android.app.ActivityThread.main([ActivityThread.java:7961](http://activitythread.java:7961/))
	at java.lang.reflect.Method.invoke(Native Method)
	at [com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run](http://com.android.internal.os.runtimeinit$methodandargscaller.run/)([RuntimeInit.java:548](http://runtimeinit.java:548/))
	at com.android.internal.os.ZygoteInit.main([ZygoteInit.java:936](http://zygoteinit.java:936/))
	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [androidx.compose.ui.platform.MotionDurationScaleImpl@80e87e2, androidx.compose.runtime.BroadcastFrameClock@662e773, StandaloneCoroutine{Cancelling}@93c630, AndroidUiDispatcher@e6e32a9]
```

### :memo: How is it being implemented?

- [x] Fix CustomDateTransformation

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots


### Before
[before.webm](https://github.com/user-attachments/assets/cd0d25c8-6972-4f5f-8d3a-80037262e8b6)


### Now
[now.webm](https://github.com/user-attachments/assets/15b4708e-96b7-496c-96d8-d2f08b60edf5)

