### PR TITLE
[SPIP] Not show isDateOfBirthKnownFieldUid warning in dialog

### DIFF
--- a/form/src/main/java/org/dhis2/form/data/FormRepositoryImpl.kt
+++ b/form/src/main/java/org/dhis2/form/data/FormRepositoryImpl.kt
@@ -11,6 +11,7 @@ import org.dhis2.form.model.OptionSetConfiguration
 import org.dhis2.form.model.RowAction
 import org.dhis2.form.model.SectionUiModelImpl
 import org.dhis2.form.model.StoreResult
+import org.dhis2.form.ui.beneficiaryHub.isDateOfBirthKnownFieldUid
 import org.dhis2.form.ui.provider.DisplayNameProvider
 import org.dhis2.form.ui.provider.LegendValueProvider
 import org.dhis2.form.ui.validation.FieldErrorMessageProvider
@@ -166,10 +167,13 @@ class FormRepositoryImpl(
             )
         } ?: emptyList()
 
+        //EyeSeeTea customization - not show warnings for isDateOfBirthKnownFieldUid (beneficiary hub)
+        val finalItemsWithWarning = itemsWithWarning.filter { it.fieldUid != isDateOfBirthKnownFieldUid }
+
         return if (isEvent) {
-            getEventResult(itemsWithErrors, itemsWithWarning, backPressed)
+            getEventResult(itemsWithErrors, finalItemsWithWarning, backPressed)
         } else {
-            getEnrollmentResult(itemsWithErrors, itemsWithWarning, backPressed)
+            getEnrollmentResult(itemsWithErrors, finalItemsWithWarning, backPressed)
         }
     }
 

--- a/form/src/main/java/org/dhis2/form/ui/FormView.kt
+++ b/form/src/main/java/org/dhis2/form/ui/FormView.kt
@@ -61,6 +61,7 @@ import org.dhis2.form.model.InfoUiModel
 import org.dhis2.form.model.RowAction
 import org.dhis2.form.model.UiRenderType
 import org.dhis2.form.model.exception.RepositoryRecordsException
+import org.dhis2.form.ui.beneficiaryHub.isDateOfBirthKnownFieldUid
 import org.dhis2.form.ui.dialog.QRDetailBottomDialog
 import org.dhis2.form.ui.event.RecyclerViewUiEvents
 import org.dhis2.form.ui.idling.FormCountingIdlingResource
@@ -415,7 +416,11 @@ class FormView : Fragment() {
     private fun showDataEntryResultDialog(result: DataIntegrityCheckResult) {
         formResultDialogUiProvider?.let {
             val modelAndFieldsWithIssuesList = getDialogModelBasedOnResult(result)
-            val fieldsWithIssues = modelAndFieldsWithIssuesList?.second ?: emptyList()
+
+
+            //EyeSeeTea customization - not show warnings for isDateOfBirthKnownFieldUid (beneficiary hub)
+            //val fieldsWithIssues = modelAndFieldsWithIssuesList?.second ?: emptyList()
+            val fieldsWithIssues = modelAndFieldsWithIssuesList?.second?.filter { it.fieldUid != isDateOfBirthKnownFieldUid } ?: emptyList()
 
             val showBottomSheetDialog = {
                 modelAndFieldsWithIssuesList?.first?.let { model ->

--- a/form/src/main/java/org/dhis2/form/ui/FormView.kt
+++ b/form/src/main/java/org/dhis2/form/ui/FormView.kt
@@ -61,7 +61,6 @@ import org.dhis2.form.model.InfoUiModel
 import org.dhis2.form.model.RowAction
 import org.dhis2.form.model.UiRenderType
 import org.dhis2.form.model.exception.RepositoryRecordsException
-import org.dhis2.form.ui.beneficiaryHub.isDateOfBirthKnownFieldUid
 import org.dhis2.form.ui.dialog.QRDetailBottomDialog
 import org.dhis2.form.ui.event.RecyclerViewUiEvents
 import org.dhis2.form.ui.idling.FormCountingIdlingResource
@@ -417,10 +416,7 @@ class FormView : Fragment() {
         formResultDialogUiProvider?.let {
             val modelAndFieldsWithIssuesList = getDialogModelBasedOnResult(result)
 
-
-            //EyeSeeTea customization - not show warnings for isDateOfBirthKnownFieldUid (beneficiary hub)
-            //val fieldsWithIssues = modelAndFieldsWithIssuesList?.second ?: emptyList()
-            val fieldsWithIssues = modelAndFieldsWithIssuesList?.second?.filter { it.fieldUid != isDateOfBirthKnownFieldUid } ?: emptyList()
+            val fieldsWithIssues = modelAndFieldsWithIssuesList?.second ?: emptyList()
 
             val showBottomSheetDialog = {
                 modelAndFieldsWithIssuesList?.first?.let { model ->


### PR DESCRIPTION
### :pushpin: References

* **Issue:** https://app.clickup.com/t/869bj9977 #869bj9977

* **Related Pull request:**

###   :gear: branches 

**app**:  

Origin: eature-spip/beneficiary_hub_not_show_isDateOfBirthKnown_warning Target: feature-spip/beneficiary_hub

**dhis2-android-SDK**:  

Origin: 79239151c4f64e9bab83750c12117314d8fea1f3

### :tophat: What is the goal?

- Avoid to save to show warning about isDateOfBirthKnown Field

### :memo: How is it being implemented?

- [x] fiter field with issues to show

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-

[Screen_recording_20251203_110351.webm](https://github.com/user-attachments/assets/3c80b7c6-c977-4bb4-81c5-3aed6607a25f)

