### PR TITLE
[SPIP] sms audit

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/DashboardViewModel.kt
@@ -197,6 +197,10 @@ class DashboardViewModel(
         fetchDashboardModel()
     }
 
+    fun updateGrouping() {
+        fetchGrouping()
+    }
+
     fun updateEventUid(uid: String?) {
         if (eventUid.value != uid) {
             this.eventUid.value = uid

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/TeiDashboardMobileActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/TeiDashboardMobileActivity.kt
@@ -881,6 +881,10 @@ class TeiDashboardMobileActivity :
             }
         }
     }
+
+    fun refreshEvents() {
+        dashboardViewModel.updateGrouping()
+    }
 }
 
 enum class EnrollmentMenuItem {

--- a/app/src/spIP/java/org/dhis2/usescases/sms/DI/ServiceLocator.kt
+++ b/app/src/spIP/java/org/dhis2/usescases/sms/DI/ServiceLocator.kt
@@ -4,6 +4,7 @@ import org.dhis2.usescases.sms.data.api.ConstantApi
 import org.dhis2.usescases.sms.data.api.ConstantApiImpl
 import org.dhis2.usescases.sms.data.api.OutboundApi
 import org.dhis2.usescases.sms.data.api.OutboundApiImpl
+import org.dhis2.usescases.sms.data.repository.audit.AuditD2Repository
 import org.dhis2.usescases.sms.data.repository.message.MessageTemplateD2Repository
 import org.dhis2.usescases.sms.data.repository.patient.PatientD2Repository
 import org.dhis2.usescases.sms.data.repository.preferred.PreferredLanguageD2Repository
@@ -15,30 +16,31 @@ import org.hisp.dhis.android.core.arch.api.HttpServiceClient
 
 object SPIPServiceLocator {
 
-  fun provideSendSmsUseCase(): SendSmsUseCase {
+    fun provideSendSmsUseCase(): SendSmsUseCase {
+        val outboundApi: OutboundApi = OutboundApiImpl(provideHttpClient())
+        val constantApi: ConstantApi = ConstantApiImpl(provideHttpClient())
 
-    val outboundApi: OutboundApi = OutboundApiImpl(provideHttpClient())
-    val constantApi: ConstantApi = ConstantApiImpl(provideHttpClient())
+        val patientRepository = PatientD2Repository(provideD2())
+        val auditRepository = AuditD2Repository(provideD2())
+        val messageTemplate = MessageTemplateD2Repository(constantApi, provideD2())
+        val preferredLanguageRepository = PreferredLanguageD2Repository(provideD2())
+        val smsRepository = SmsApiRepository(outboundApi)
 
-    val patientRepository = PatientD2Repository(provideD2())
-    val messageTemplate = MessageTemplateD2Repository(constantApi, provideD2())
-    val preferredLanguageRepository = PreferredLanguageD2Repository(provideD2())
-    val smsRepository = SmsApiRepository(outboundApi)
+        return SendSmsUseCase(
+            patientRepository,
+            messageTemplate,
+            preferredLanguageRepository,
+            smsRepository,
+            auditRepository
+        )
+    }
 
-    return SendSmsUseCase(
-      patientRepository,
-      messageTemplate,
-      preferredLanguageRepository,
-      smsRepository
-    )
-  }
+    private fun provideD2(): D2 {
+        return D2Manager.getD2()
+    }
 
-  private fun provideD2(): D2 {
-    return D2Manager.getD2()
-  }
-
-  private fun provideHttpClient(): HttpServiceClient {
-    return D2Manager.getD2().httpServiceClient()
-  }
+    private fun provideHttpClient(): HttpServiceClient {
+        return D2Manager.getD2().httpServiceClient()
+    }
 
 }

--- a/app/src/spIP/java/org/dhis2/usescases/sms/data/repository/audit/AuditD2Repository.kt
+++ b/app/src/spIP/java/org/dhis2/usescases/sms/data/repository/audit/AuditD2Repository.kt
@@ -5,6 +5,7 @@ import org.dhis2.usescases.sms.domain.model.audit.Audit
 import org.dhis2.usescases.sms.domain.repository.audit.AuditRepository
 import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.event.EventCreateProjection
+import org.hisp.dhis.android.core.event.EventStatus
 
 private const val program = "SdHQreF7gdU"
 private const val programStage = "IsrH6YFBfnM"
@@ -73,6 +74,8 @@ class AuditD2Repository(
                 .value(eventUid, translatedMessageDE)
                 .blockingSet(translatedMessage)
         }
+
+        d2.eventModule().events().uid(eventUid).setStatus(EventStatus.COMPLETED)
     }
 
     private fun formatDateToUTC(date: java.util.Date): String {

--- a/app/src/spIP/java/org/dhis2/usescases/sms/data/repository/audit/AuditD2Repository.kt
+++ b/app/src/spIP/java/org/dhis2/usescases/sms/data/repository/audit/AuditD2Repository.kt
@@ -1,0 +1,81 @@
+package org.dhis2.usescases.sms.data.repository.audit
+
+import org.dhis2.commons.date.DateUtils
+import org.dhis2.usescases.sms.domain.model.audit.Audit
+import org.dhis2.usescases.sms.domain.repository.audit.AuditRepository
+import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.event.EventCreateProjection
+
+private const val program = "SdHQreF7gdU"
+private const val programStage = "IsrH6YFBfnM"
+private const val dateDE = "lyw4MJ2v1p3"
+private const val messageDE = "fws849y4UCG"
+private const val translatedMessageDE = "gNFQebWtsb5"
+private const val lastSMSSentAttribute = "QOlXGMKCtjQ"
+
+class AuditD2Repository(
+    private val d2: D2,
+) : AuditRepository {
+
+    override suspend fun save(audit: Audit) {
+        val tei = d2.trackedEntityModule().trackedEntityInstances()
+            .withTrackedEntityAttributeValues()
+            .uid(audit.patientUid).blockingGet()
+            ?: throw IllegalArgumentException("No TEI found with uid: ${audit.patientUid}")
+
+        updateLastSentAttribute(tei.uid(), audit)
+
+        createAuditEvent(tei.uid(),audit)
+    }
+
+    private fun updateLastSentAttribute(teiUid:String,audit: Audit){
+        val formattedDate = formatDateToUTC(audit.date)
+
+        d2.trackedEntityModule().trackedEntityAttributeValues()
+            .value(lastSMSSentAttribute, teiUid)
+            .blockingSet(formattedDate)
+    }
+
+    private fun createAuditEvent(teiUid:String, audit: Audit){
+        val enrollments = d2.enrollmentModule().enrollments()
+            .byTrackedEntityInstance().eq(teiUid)
+            .byProgram().eq(program).blockingGet()
+
+        val enrollment = enrollments.firstOrNull()
+            ?: throw IllegalArgumentException("No enrollment found for TEI with uid: ${audit.patientUid}")
+
+        val orgUnitUid = enrollment.organisationUnit()
+            ?: throw IllegalArgumentException("No organisation unit found for enrollment: ${enrollment.uid()}")
+
+
+        val eventUid = d2.eventModule().events().blockingAdd(
+            EventCreateProjection.builder()
+                .enrollment(enrollment.uid())
+                .program(program)
+                .programStage(programStage)
+                .organisationUnit(orgUnitUid)
+                .build()
+        )
+
+        d2.eventModule().events().uid(eventUid).setEventDate(audit.date)
+
+        val formattedAuditDate = formatDateToUTC(audit.date)
+        d2.trackedEntityModule().trackedEntityDataValues()
+            .value(eventUid, dateDE)
+            .blockingSet(formattedAuditDate)
+
+        d2.trackedEntityModule().trackedEntityDataValues()
+            .value(eventUid, messageDE)
+            .blockingSet(audit.message)
+
+        audit.translatedMessage?.let { translatedMessage ->
+            d2.trackedEntityModule().trackedEntityDataValues()
+                .value(eventUid, translatedMessageDE)
+                .blockingSet(translatedMessage)
+        }
+    }
+
+    private fun formatDateToUTC(date: java.util.Date): String {
+        return DateUtils.databaseDateFormatNoZulu().format(date)
+    }
+}

--- a/app/src/spIP/java/org/dhis2/usescases/sms/data/repository/patient/PatientD2Repository.kt
+++ b/app/src/spIP/java/org/dhis2/usescases/sms/data/repository/patient/PatientD2Repository.kt
@@ -22,7 +22,6 @@ class PatientD2Repository(
     return buildPatient(tei)
   }
 
-
   private fun buildPatient(
     tei: TrackedEntityInstance
   ): Patient {

--- a/app/src/spIP/java/org/dhis2/usescases/sms/domain/model/audit/Audit.kt
+++ b/app/src/spIP/java/org/dhis2/usescases/sms/domain/model/audit/Audit.kt
@@ -1,0 +1,10 @@
+package org.dhis2.usescases.sms.domain.model.audit
+
+import java.util.Date
+
+data class Audit(
+    val patientUid: String,
+    val date: Date,
+    val message: String,
+    val translatedMessage: String?
+)

--- a/app/src/spIP/java/org/dhis2/usescases/sms/domain/model/sms/Message.kt
+++ b/app/src/spIP/java/org/dhis2/usescases/sms/domain/model/sms/Message.kt
@@ -1,6 +1,7 @@
 package org.dhis2.usescases.sms.domain.model.sms
 
 data class Message(
-  val text: String,
-  val recipients: List<String>
+    val text: String,
+    val recipients: List<String>,
+    val language: String,
 )

--- a/app/src/spIP/java/org/dhis2/usescases/sms/domain/repository/audit/AuditRepository.kt
+++ b/app/src/spIP/java/org/dhis2/usescases/sms/domain/repository/audit/AuditRepository.kt
@@ -1,0 +1,7 @@
+package org.dhis2.usescases.sms.domain.repository.audit
+
+import org.dhis2.usescases.sms.domain.model.audit.Audit
+
+interface AuditRepository {
+  suspend fun save(audit: Audit)
+}

--- a/app/src/spIP/java/org/dhis2/usescases/sms/domain/usecase/SendSmsUseCase.kt
+++ b/app/src/spIP/java/org/dhis2/usescases/sms/domain/usecase/SendSmsUseCase.kt
@@ -1,66 +1,90 @@
 package org.dhis2.usescases.sms.domain.usecase
 
 import org.dhis2.usescases.sms.data.model.MessageTemplate
+import org.dhis2.usescases.sms.domain.model.audit.Audit
+import org.dhis2.usescases.sms.domain.model.patient.Patient
 import org.dhis2.usescases.sms.domain.model.sms.Message
 import org.dhis2.usescases.sms.domain.model.sms.SmsResult
+import org.dhis2.usescases.sms.domain.repository.audit.AuditRepository
 import org.dhis2.usescases.sms.domain.repository.message.MessageTemplateRepository
 import org.dhis2.usescases.sms.domain.repository.patient.PatientRepository
 import org.dhis2.usescases.sms.domain.repository.preferred.PreferredLanguageRepository
 import org.dhis2.usescases.sms.domain.repository.sms.SmsRepository
+import java.util.Date
 
 
 class SendSmsUseCase(
-  private val patientRepository: PatientRepository,
-  private val smsTemplateRepository: MessageTemplateRepository,
-  private val preferredLanguageRepository: PreferredLanguageRepository,
-  private val smsRepository: SmsRepository
+    private val patientRepository: PatientRepository,
+    private val smsTemplateRepository: MessageTemplateRepository,
+    private val preferredLanguageRepository: PreferredLanguageRepository,
+    private val smsRepository: SmsRepository,
+    private val auditRepository: AuditRepository
 ) {
-  suspend fun invoke(uid: String):SmsResult{
-    val patient = patientRepository.getByUid(uid)
+    suspend fun invoke(uid: String): SmsResult {
+        val patient = patientRepository.getByUid(uid)
 
-    val messageTemplate = getMessageTemplate(patient.preferredLanguage)
-      ?: return SmsResult.TemplateFailure
+        val message = createMessage(patient)
+            ?: return SmsResult.TemplateFailure
 
-    val message = Message(
-      text = messageTemplate.text
-        .replace("{{fullName}}", patient.name)
-        .replace("{{patientNumber}}", patient.number),
-      recipients = listOf(cleanupPhoneNumber(patient.phone))
-    )
+        try {
+            smsRepository.send(message)
 
-    try {
-      smsRepository.send(message)
+            val audit = createAudit(patient, message)
 
-      return if (patient.preferredLanguage != "en" && messageTemplate.language == "en") {
-        val language = preferredLanguageRepository.getByCode(patient.preferredLanguage)
+            auditRepository.save(audit)
 
-        SmsResult.SuccessUsingEn(language.name)
-      } else {
-        SmsResult.Success
-      }
-    } catch (e: Exception) {
-      return SmsResult.SendFailure
+            return if (patient.preferredLanguage != "en" && message.language == "en") {
+                val language = preferredLanguageRepository.getByCode(patient.preferredLanguage)
+
+                SmsResult.SuccessUsingEn(language.name)
+            } else {
+                SmsResult.Success
+            }
+        } catch (e: Exception) {
+            return SmsResult.SendFailure
+        }
+
     }
 
-  }
+    private suspend fun createMessage(patient: Patient, forcedLanguage: String? = null): Message? {
+        val messageTemplate = getMessageTemplate(forcedLanguage ?: patient.preferredLanguage)
+            ?: return null
 
-  private suspend fun getMessageTemplate(language: String): MessageTemplate? {
-    val messageTemplate = smsTemplateRepository.getByLanguage(language)
-
-    return if (messageTemplate.isSome()) {
-      messageTemplate.getOrThrow()
-    } else {
-      val defaultMessageTemplate = smsTemplateRepository.getByLanguage("en")
-
-      if (defaultMessageTemplate.isSome()) {
-        defaultMessageTemplate.getOrThrow()
-      } else {
-        return null
-      }
+        return Message(
+            text = messageTemplate.text
+                .replace("{{fullName}}", patient.name)
+                .replace("{{patientNumber}}", patient.number),
+            recipients = listOf(cleanupPhoneNumber(patient.phone)),
+            language = patient.preferredLanguage
+        )
     }
-  }
 
-  private fun cleanupPhoneNumber(phoneNumber: String): String {
-    return phoneNumber.replace(Regex("\\D"), "")
-  }
+    private suspend fun getMessageTemplate(language: String): MessageTemplate? {
+        val messageTemplate = smsTemplateRepository.getByLanguage(language)
+
+        return if (messageTemplate.isSome()) {
+            messageTemplate.getOrThrow()
+        } else {
+            val defaultMessageTemplate = smsTemplateRepository.getByLanguage("en")
+
+            if (defaultMessageTemplate.isSome()) {
+                defaultMessageTemplate.getOrThrow()
+            } else {
+                return null
+            }
+        }
+    }
+
+    private suspend fun createAudit(patient: Patient, message: Message): Audit {
+        val translatedMessage =
+            if (message.language != "en")
+                createMessage(patient, "en")?.text
+            else null
+
+        return Audit( patient.uid, Date(), message.text, translatedMessage)
+    }
+
+    private fun cleanupPhoneNumber(phoneNumber: String): String {
+        return phoneNumber.replace(Regex("\\D"), "")
+    }
 }

--- a/app/src/spIP/java/org/dhis2/usescases/sms/domain/usecase/SendSmsUseCase.kt
+++ b/app/src/spIP/java/org/dhis2/usescases/sms/domain/usecase/SendSmsUseCase.kt
@@ -55,7 +55,7 @@ class SendSmsUseCase(
                 .replace("{{fullName}}", patient.name)
                 .replace("{{patientNumber}}", patient.number),
             recipients = listOf(cleanupPhoneNumber(patient.phone)),
-            language = patient.preferredLanguage
+            language = messageTemplate.language
         )
     }
 

--- a/app/src/spIP/java/org/dhis2/usescases/teiDashboard/TeiDashboardMenu.kt
+++ b/app/src/spIP/java/org/dhis2/usescases/teiDashboard/TeiDashboardMenu.kt
@@ -8,92 +8,109 @@ import androidx.lifecycle.lifecycleScope
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.dhis2.R
 import org.dhis2.usescases.sms.DI.SPIPServiceLocator
 import org.dhis2.usescases.sms.domain.model.sms.SmsResult
 
 fun customClick(
-  menuId: EnrollmentMenuItem,
-  teiDashboardMobileActivity: TeiDashboardMobileActivity,
-  programUid: String,
-  enrollmentUid: String,
-  teiUid: String
+    menuId: EnrollmentMenuItem,
+    teiDashboardMobileActivity: TeiDashboardMobileActivity,
+    programUid: String,
+    enrollmentUid: String,
+    teiUid: String
 ) {
-  when(menuId){
-    EnrollmentMenuItem.SEND_SMS -> {
-      sendSms(
-        teiDashboardMobileActivity,
-        teiDashboardMobileActivity.binding.root,
-        teiUid
-      )
+    when (menuId) {
+        EnrollmentMenuItem.SEND_SMS -> {
+            sendSms(
+                activity = teiDashboardMobileActivity,
+                parentView = teiDashboardMobileActivity.binding.root,
+                teiUid = teiUid
+            )
+        }
+
+        else -> {}
     }
-    else ->{}
-  }
 }
 
 
-fun sendSms(activity: AppCompatActivity, parentView: View, teiUid: String) {
-  activity.lifecycleScope.launch(Dispatchers.IO) {
-    when (val result = SPIPServiceLocator.provideSendSmsUseCase().invoke(teiUid)) {
-      is SmsResult.Success -> {
-        showCustomSnackbar(
-          activity,
-          parentView,
-          activity.getString(R.string.sent_sms_successfully),
-          true
-        )
-      }
+fun sendSms(
+    activity: TeiDashboardMobileActivity,
+    parentView: View,
+    teiUid: String
+) {
+    activity.lifecycleScope.launch(Dispatchers.IO) {
+        when (val result = SPIPServiceLocator.provideSendSmsUseCase().invoke(teiUid)) {
+            is SmsResult.Success -> {
+                withContext(Dispatchers.Main) {
+                    showCustomSnackbar(
+                        activity,
+                        parentView,
+                        activity.getString(R.string.sent_sms_successfully),
+                        true
+                    )
 
-      is SmsResult.SuccessUsingEn -> {
-        showCustomSnackbar(
-          activity,
-          parentView,
-          activity.getString(
-            R.string.sent_sms_using_en_successfully,
-            result.preferredLanguage
-          ),
-          true
-        )
-      }
+                    activity.refreshEvents()
+                }
+            }
 
-      is SmsResult.TemplateFailure -> {
-        showCustomSnackbar(
-          activity,
-          parentView,
-          activity.getString(R.string.sent_sms_template_error),
-          false
-        )
-      }
+            is SmsResult.SuccessUsingEn -> {
+                withContext(Dispatchers.Main) {
+                    showCustomSnackbar(
+                        activity,
+                        parentView,
+                        activity.getString(
+                            R.string.sent_sms_using_en_successfully,
+                            result.preferredLanguage
+                        ),
+                        true
+                    )
+                    activity.refreshEvents()
+                }
+            }
 
-      is SmsResult.SendFailure -> {
-        showCustomSnackbar(
-          activity,
-          parentView,
-          activity.getString(R.string.sent_sms_error),
-          false
-        )
-      }
+            is SmsResult.TemplateFailure -> {
+                withContext(Dispatchers.Main) {
+                    showCustomSnackbar(
+                        activity,
+                        parentView,
+                        activity.getString(R.string.sent_sms_template_error),
+                        false
+                    )
+                }
+            }
+
+            is SmsResult.SendFailure -> {
+                withContext(Dispatchers.Main) {
+                    showCustomSnackbar(
+                        activity,
+                        parentView,
+                        activity.getString(R.string.sent_sms_error),
+                        false
+                    )
+                }
+            }
+        }
     }
-  }
 }
 
 fun showCustomSnackbar(
-  activity: AppCompatActivity,
-  parentView: View,
-  message: String,
-  isSuccess: Boolean
+    activity: AppCompatActivity,
+    parentView: View,
+    message: String,
+    isSuccess: Boolean
 ) {
-  val snackbar = Snackbar.make(parentView, message, Snackbar.LENGTH_SHORT)
+    val snackbar = Snackbar.make(parentView, message, Snackbar.LENGTH_SHORT)
 
-  val color =
-    if (isSuccess) ContextCompat.getColor(activity, R.color.colorPrimaryDark_2e7)
-    else ContextCompat.getColor(activity, R.color.colorPrimaryDarkRed)
+    val color =
+        if (isSuccess) ContextCompat.getColor(activity, R.color.colorPrimaryDark_2e7)
+        else ContextCompat.getColor(activity, R.color.colorPrimaryDarkRed)
 
-  snackbar.setBackgroundTint(color)
+    snackbar.setBackgroundTint(color)
 
-  snackbar.view.findViewById<TextView>(R.id.snackbar_text)?.apply {
-    maxLines = Int.MAX_VALUE
-  }
+    snackbar.view.findViewById<TextView>(R.id.snackbar_text)?.apply {
+        maxLines = Int.MAX_VALUE
+    }
 
-  snackbar.show()
+    snackbar.show()
 }

--- a/app/src/testSpIP/java/org/dhis2/usescases/sms/domain/usecase/SendSmsUseCaseTest.kt
+++ b/app/src/testSpIP/java/org/dhis2/usescases/sms/domain/usecase/SendSmsUseCaseTest.kt
@@ -8,6 +8,7 @@ import org.dhis2.usescases.sms.domain.model.preffered.PreferredLanguage
 import org.dhis2.usescases.sms.domain.model.sms.Message
 import org.dhis2.usescases.sms.domain.model.sms.SmsResult
 import org.dhis2.usescases.sms.domain.model.types.Maybe
+import org.dhis2.usescases.sms.domain.repository.audit.AuditRepository
 import org.dhis2.usescases.sms.domain.repository.message.MessageTemplateRepository
 import org.dhis2.usescases.sms.domain.repository.patient.PatientRepository
 import org.dhis2.usescases.sms.domain.repository.preferred.PreferredLanguageRepository
@@ -24,146 +25,165 @@ import org.mockito.kotlin.whenever
 @ExperimentalCoroutinesApi
 class SendSmsUseCaseTest {
 
-  @Mock
-  lateinit var patientRepository: PatientRepository
+    @Mock
+    lateinit var patientRepository: PatientRepository
 
-  @Mock
-  lateinit var messageTemplateRepository: MessageTemplateRepository
+    @Mock
+    lateinit var messageTemplateRepository: MessageTemplateRepository
 
-  @Mock
-  lateinit var smsRepository: SmsRepository
+    @Mock
+    lateinit var smsRepository: SmsRepository
 
-  @Mock
-  lateinit var preferredLanguageRepository: PreferredLanguageRepository
+    @Mock
+    lateinit var auditRepository: AuditRepository
 
-  private val defaultEnMessageTemplate = "Default message template"
+    @Mock
+    lateinit var preferredLanguageRepository: PreferredLanguageRepository
 
-  @Test
-  fun `should send expected es message to expected number`() = runTest {
-    val phone = "1234567890"
+    private val defaultEnMessageTemplate = "Default message template"
 
-    val useCase = givenAPatientAndATemplate(
-      phone = phone,
-      number = "123-456",
-      preferredLanguage = "es",
-      messageTemplate = "Hola {{fullName}}, tu numero de paciente es {{patientNumber}}"
-    )
+    @Test
+    fun `should send expected es message to expected number`() = runTest {
+        val phone = "1234567890"
 
-    val result = useCase.invoke("PATIENT_UID")
-
-    val expectedMessage = Message(
-      text = "Hola John Doe, tu numero de paciente es 123-456",
-      recipients = listOf(phone)
-    )
-
-    verify(smsRepository).send(expectedMessage)
-    assert(result is SmsResult.Success)
-  }
-
-  @Test
-  fun `should use default en template if there is not template for specific language`() = runTest {
-    val phone = "1234567890"
-
-    val useCase = givenAPatientAndATemplate(
-      phone = phone,
-      preferredLanguage = "es",
-      messageTemplate =  null
-    )
-
-    val result = useCase.invoke("PATIENT_UID")
-
-    val expectedMessage = Message(
-      text = defaultEnMessageTemplate,
-      recipients = listOf(phone)
-    )
-
-    verify(smsRepository).send(expectedMessage)
-    assert(result is SmsResult.SuccessUsingEn)
-  }
-
-  @Test
-  fun `should return template failure if there are not any template`() = runTest {
-    val useCase = givenAPatientAndATemplate(
-      messageTemplate = null,
-      createDefaultEnTemplate = false
-    )
-
-    val result = useCase.invoke("PATIENT_UID")
-
-    assert(result is SmsResult.TemplateFailure)
-  }
-
-  @Test
-  fun `should return send failure if send throw and error`() = runTest {
-    val useCase = givenAPatientAndATemplate()
-
-    givenAErrortoSendEmail()
-
-    val result = useCase.invoke("PATIENT_UID")
-
-    assert(result is SmsResult.SendFailure)
-  }
-
-
-  private suspend fun givenAPatientAndATemplate(
-    phone: String = "1234567890",
-    number: String = "123-456",
-    preferredLanguage: String = "es",
-    messageTemplate: String?=  "Hola {{fullName}}, tu numero de paciente es {{patientNumber}}",
-    createDefaultEnTemplate: Boolean = true
-  ): SendSmsUseCase {
-
-    whenever(preferredLanguageRepository.getByCode(any())).thenReturn(PreferredLanguage("PATIENT_UID", "en", "English"))
-
-    whenever(
-      patientRepository.getByUid(any())
-    ).thenReturn(
-      Patient(
-        "PATIENT_UID",
-        number,
-        "John Doe",
-        phone,
-        preferredLanguage
-      )
-    )
-
-    if (messageTemplate == null) {
-      whenever(
-        messageTemplateRepository.getByLanguage(preferredLanguage)
-      ).thenReturn(Maybe.None)
-    } else {
-      whenever(
-        messageTemplateRepository.getByLanguage(preferredLanguage)
-      ).thenReturn(Maybe.Some(MessageTemplate(text = messageTemplate, language = preferredLanguage)))
-    }
-
-    if (createDefaultEnTemplate) {
-      whenever(
-        messageTemplateRepository.getByLanguage("en")
-      ).thenReturn(
-        Maybe.Some(
-          MessageTemplate(
-            text = defaultEnMessageTemplate,
-            language = "en"
-          )
+        val useCase = givenAPatientAndATemplate(
+            phone = phone,
+            number = "123-456",
+            preferredLanguage = "es",
+            messageTemplate = "Hola {{fullName}}, tu numero de paciente es {{patientNumber}}"
         )
-      )
-    } else {
-      whenever(
-        messageTemplateRepository.getByLanguage("en")
-      ).thenReturn(Maybe.None)
+
+        val result = useCase.invoke("PATIENT_UID")
+
+        val expectedMessage = Message(
+            text = "Hola John Doe, tu numero de paciente es 123-456",
+            recipients = listOf(phone), language = "es"
+        )
+
+        verify(smsRepository).send(expectedMessage)
+        assert(result is SmsResult.Success)
     }
 
-    return SendSmsUseCase(
-      patientRepository = patientRepository,
-      smsTemplateRepository = messageTemplateRepository,
-      preferredLanguageRepository = preferredLanguageRepository,
-      smsRepository = smsRepository
-    )
-  }
+    @Test
+    fun `should use default en template if there is not template for specific language`() =
+        runTest {
+            val phone = "1234567890"
 
-  private suspend fun givenAErrortoSendEmail() {
-    whenever(smsRepository.send(any())).thenThrow(RuntimeException("Send error"))
-  }
+            val useCase = givenAPatientAndATemplate(
+                phone = phone,
+                preferredLanguage = "es",
+                messageTemplate = null
+            )
+
+            val result = useCase.invoke("PATIENT_UID")
+
+            val expectedMessage = Message(
+                text = defaultEnMessageTemplate,
+                recipients = listOf(phone),
+                language = "en"
+            )
+
+            verify(smsRepository).send(expectedMessage)
+            assert(result is SmsResult.SuccessUsingEn)
+        }
+
+    @Test
+    fun `should return template failure if there are not any template`() = runTest {
+        val useCase = givenAPatientAndATemplate(
+            messageTemplate = null,
+            createDefaultEnTemplate = false
+        )
+
+        val result = useCase.invoke("PATIENT_UID")
+
+        assert(result is SmsResult.TemplateFailure)
+    }
+
+    @Test
+    fun `should return send failure if send throw and error`() = runTest {
+        val useCase = givenAPatientAndATemplate()
+
+        givenAErrortoSendEmail()
+
+        val result = useCase.invoke("PATIENT_UID")
+
+        assert(result is SmsResult.SendFailure)
+    }
+
+
+    private suspend fun givenAPatientAndATemplate(
+        phone: String = "1234567890",
+        number: String = "123-456",
+        preferredLanguage: String = "es",
+        messageTemplate: String? = "Hola {{fullName}}, tu numero de paciente es {{patientNumber}}",
+        createDefaultEnTemplate: Boolean = true
+    ): SendSmsUseCase {
+
+        whenever(preferredLanguageRepository.getByCode(any())).thenReturn(
+            PreferredLanguage(
+                "PATIENT_UID",
+                "en",
+                "English"
+            )
+        )
+
+        whenever(
+            patientRepository.getByUid(any())
+        ).thenReturn(
+            Patient(
+                "PATIENT_UID",
+                number,
+                "John Doe",
+                phone,
+                preferredLanguage
+            )
+        )
+
+        if (messageTemplate == null) {
+            whenever(
+                messageTemplateRepository.getByLanguage(preferredLanguage)
+            ).thenReturn(Maybe.None)
+        } else {
+            whenever(
+                messageTemplateRepository.getByLanguage(preferredLanguage)
+            ).thenReturn(
+                Maybe.Some(
+                    MessageTemplate(
+                        text = messageTemplate,
+                        language = preferredLanguage
+                    )
+                )
+            )
+        }
+
+        if (createDefaultEnTemplate) {
+            whenever(
+                messageTemplateRepository.getByLanguage("en")
+            ).thenReturn(
+                Maybe.Some(
+                    MessageTemplate(
+                        text = defaultEnMessageTemplate,
+                        language = "en"
+                    )
+                )
+            )
+        } else {
+            whenever(
+                messageTemplateRepository.getByLanguage("en")
+            ).thenReturn(Maybe.None)
+        }
+
+        return SendSmsUseCase(
+            patientRepository = patientRepository,
+            smsTemplateRepository = messageTemplateRepository,
+            preferredLanguageRepository = preferredLanguageRepository,
+            smsRepository = smsRepository,
+            auditRepository = auditRepository
+        )
+    }
+
+    private suspend fun givenAErrortoSendEmail() {
+        whenever(smsRepository.send(any())).thenThrow(RuntimeException("Send error"))
+    }
 
 }


### PR DESCRIPTION
### :pushpin: References

* **Issue:** https://app.clickup.com/t/869bpu999 #869bpu999

* **Related Pull request:**

###   :gear: branches 

**app**:  

Origin:feature-spip/sms_audit Target: develop-spip

**dhis2-android-SDK**:  

Origin: 79239151c4f64e9bab83750c12117314d8fea1f3

### :tophat: What is the goal?

Request from client: is it possible to create an event that could track when an SMS is sent? Maybe when the button is pressed, it would show the date, time, and message type that was sent. We could show it in the enrollment dashboard.

Notes from PM: This has been already implemented by Matías for the web interface. However, we have a customisation for Android that allows to 'Send Welcome SMS'. We need to implement this very same behavior when 'Send Welcome SMS' button his hit.

Repeatable Program Stage already created → SMS

DEs available on the Program Stage:
Date & Time → Date & Time
Message Sent → Long Text 
Message Sent (Translated) → Long Text
Only applies if SMS sent is not in English

For each SMS sent using CMO SMS feature, a new Program Stage to be created filling up those values.

### :memo: How is it being implemented?

- [x] Create event audit
- [x] Update last sent attribute
- [x] Refresh events after successful sent SMS

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-