### PR TITLE
[SPIP] Fix crash top clear radio button

### DIFF
--- a/form/src/main/java/org/dhis2/form/ui/provider/inputfield/RadioButtonProvider.kt
+++ b/form/src/main/java/org/dhis2/form/ui/provider/inputfield/RadioButtonProvider.kt
@@ -57,7 +57,7 @@ internal fun ProvideRadioButtonInput(
             intentHandler(
                 FormIntent.OnSave(
                     fieldUiModel.uid,
-                    codeList[selectedIndex],
+                    if (item != null) codeList[selectedIndex] else null,
                     fieldUiModel.valueType,
                 ),
             )


### PR DESCRIPTION
### :pushpin: References

* **Issue:** https://app.clickup.com/t/869bxbckr #869bxbckr

* **Related Pull request:**

###   :gear: branches 

**app**:  

Origin:fix/crash_to_clear_radio_button  Target: develop-spip

**dhis2-android-SDK**:  

Origin: 79239151c4f64e9bab83750c12117314d8fea1f3

### :tophat: What is the goal?

(note that this is also happening on the ANC form on the Report/OtherLabs/Ultrasounds section
create a new OPD event
open the diagnostics section
click positive or negative for test
click the "x" to clear the value
the app crashes

### :memo: How is it being implemented?

- [x] Fix the bug in the official code

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-