### PR TITLE
[Simprints] Bugfix for empty biometric search results on projects without Simprints external credential

### DIFF
--- a/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/BiometricsClient.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/BiometricsClient.kt
@@ -36,6 +36,19 @@ import timber.log.Timber
 // TODO: This constants should be in libsimprints
 private const val SIMPRINTS_HAS_CREDENTIALS = "hasCredential"
 private const val SIMPRINTS_SCANNED_CREDENTIAL = "scannedCredential"
+/*
+When SIMPRINTS_HAS_CREDENTIALS is false,
+Simprints ID expects a "versionCode" intent extra in order to return data encoded as JSON:
+see https://github.com/Simprints/Android-Simprints-ID/blob/v2025.4.0/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/response/LibSimprintsResponseMapper.kt#L62
+LibSimprints include this as a constant since v2025.1.1:
+see https://github.com/Simprints/LibSimprints/blob/v2025.1.1-SNAPSHOT/src/main/java/com/simprints/libsimprints/Constants.kt#L38
+and also https://github.com/Simprints/LibSimprints/blob/v2025.2.1/src/main/java/com/simprints/libsimprints/contracts/VersionsList.kt#L15
+However, LibSimprints v2025.1.1 minSdk is higher than DHIS2 3.2.1.1-simprints-fork-8 has.
+These key and value are backported from the newer (unsupported) LibSimprints versions
+to enable JSON formatting in data returned by Simprints ID.
+ */
+private const val SIMPRINTS_VERSION_CODE_KEY = "versionCode"
+private const val SIMPRINTS_VERSION_CODE_VALUE_INITIAL_REWORK = 20250102
 
 class BiometricsClient(
     projectId: String,
@@ -531,7 +544,7 @@ class BiometricsClient(
         requestCode: Int
     ) {
         try {
-            activity.startActivityForResult(intent, requestCode)
+            activity.startActivityForResult(intent.addJsonSupportToSimprintsResponse(), requestCode)
         } catch (ex: ActivityNotFoundException) {
             Toast.makeText(activity, R.string.biometrics_download_app, Toast.LENGTH_SHORT).show()
         }
@@ -543,7 +556,7 @@ class BiometricsClient(
         requestCode: Int
     ) {
         try {
-            fragment.startActivityForResult(intent, requestCode)
+            fragment.startActivityForResult(intent.addJsonSupportToSimprintsResponse(), requestCode)
         } catch (ex: ActivityNotFoundException) {
             fragment.context?.let {
                 Toast.makeText(
@@ -554,6 +567,9 @@ class BiometricsClient(
             }
         }
     }
+
+    private fun Intent.addJsonSupportToSimprintsResponse(): Intent =
+        putExtra(SIMPRINTS_VERSION_CODE_KEY, SIMPRINTS_VERSION_CODE_VALUE_INITIAL_REWORK)
 
     private fun createMetadata(
         trackedEntityInstanceUId: String?,

--- a/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/BiometricsClient.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/BiometricsClient.kt
@@ -13,8 +13,6 @@ import com.simprints.libsimprints.Metadata
 import com.simprints.libsimprints.RefusalForm
 import com.simprints.libsimprints.Registration
 import com.simprints.libsimprints.SimHelper
-import com.simprints.libsimprints.Tier
-import com.simprints.libsimprints.Verification
 import org.dhis2.R
 import org.dhis2.commons.biometrics.BIOMETRICS_CONFIRM_IDENTITY_REQUEST
 import org.dhis2.commons.biometrics.BIOMETRICS_ENROLL_LAST_REQUEST
@@ -29,8 +27,10 @@ import org.dhis2.data.biometrics.biometricsClient.models.SimprintsConfirmIdentit
 import org.dhis2.data.biometrics.biometricsClient.models.SimprintsIdentifiedItem
 import org.dhis2.data.biometrics.biometricsClient.models.SimprintsRegisteredItem
 import org.dhis2.data.biometrics.biometricsClient.models.VerifyResult
+import org.dhis2.data.biometrics.biometricsClient.models.sid.ConfidenceBandSID
 import org.dhis2.data.biometrics.biometricsClient.models.sid.IdentificationSID
 import org.dhis2.data.biometrics.biometricsClient.models.sid.ScannedCredentialSID
+import org.dhis2.data.biometrics.biometricsClient.models.sid.VerificationSID
 import timber.log.Timber
 
 // TODO: This constants should be in libsimprints
@@ -517,12 +517,22 @@ class BiometricsClient(
     }
 
     private fun getVerificationJudgementByDhis2(data: Intent): VerifyResult {
-        val verification: Verification? =
-            data.getParcelableExtra(Constants.SIMPRINTS_VERIFICATION)
+        val verificationJson = data.getStringExtra(Constants.SIMPRINTS_VERIFICATION)
+        val verification: VerificationSID? = verificationJson?.let {
+            Gson().fromJson(it, VerificationSID::class.java)
+        }
+        val confidenceBand = verification?.let {
+            runCatching {
+                ConfidenceBandSID.valueOf(verification.confidenceBand)
+            }.getOrElse {
+                Timber.e("Verify returns data with unsupported confidence band: ${verification.confidenceBand}")
+                null
+            }
+        }
 
-        return if (verification != null) {
-            when (verification.tier) {
-                Tier.TIER_1, Tier.TIER_2, Tier.TIER_3, Tier.TIER_4 -> {
+        return if (confidenceBand != null) {
+            when (confidenceBand) {
+                ConfidenceBandSID.HIGH, ConfidenceBandSID.MEDIUM, ConfidenceBandSID.LOW -> {
                     if (verification.confidence >= confidenceScoreFilter) {
                         VerifyResult.Match
                     } else {
@@ -531,7 +541,7 @@ class BiometricsClient(
                     }
                 }
 
-                Tier.TIER_5 -> VerifyResult.NoMatch
+                ConfidenceBandSID.NONE -> VerifyResult.NoMatch
             }
         } else {
             VerifyResult.Failure

--- a/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/BiometricsClient.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/BiometricsClient.kt
@@ -3,15 +3,11 @@ package org.dhis2.data.biometrics.biometricsClient
 import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.os.Build
-import android.os.Parcelable
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.google.gson.Gson
 import com.simprints.libsimprints.Constants
 import com.simprints.libsimprints.Metadata
-import com.simprints.libsimprints.RefusalForm
-import com.simprints.libsimprints.Registration
 import com.simprints.libsimprints.SimHelper
 import org.dhis2.R
 import org.dhis2.commons.biometrics.BIOMETRICS_CONFIRM_IDENTITY_REQUEST
@@ -29,6 +25,8 @@ import org.dhis2.data.biometrics.biometricsClient.models.SimprintsRegisteredItem
 import org.dhis2.data.biometrics.biometricsClient.models.VerifyResult
 import org.dhis2.data.biometrics.biometricsClient.models.sid.ConfidenceBandSID
 import org.dhis2.data.biometrics.biometricsClient.models.sid.IdentificationSID
+import org.dhis2.data.biometrics.biometricsClient.models.sid.RefusalFormSID
+import org.dhis2.data.biometrics.biometricsClient.models.sid.RegistrationSID
 import org.dhis2.data.biometrics.biometricsClient.models.sid.ScannedCredentialSID
 import org.dhis2.data.biometrics.biometricsClient.models.sid.VerificationSID
 import timber.log.Timber
@@ -49,6 +47,7 @@ to enable JSON formatting in data returned by Simprints ID.
  */
 private const val SIMPRINTS_VERSION_CODE_KEY = "versionCode"
 private const val SIMPRINTS_VERSION_CODE_VALUE_INITIAL_REWORK = 20250102
+private const val SIMPRINTS_ENROLMENT_KEY = "enrolment"
 
 class BiometricsClient(
     projectId: String,
@@ -188,11 +187,10 @@ class BiometricsClient(
         val biometricsCompleted = checkBiometricsCompleted(data)
 
         val handleRegister = {
-            val registration: Registration? =
-                data.extractParcelableExtra(
-                    Constants.SIMPRINTS_REGISTRATION,
-                    Registration::class.java
-                )
+            val registrationJson = data.getStringExtra(SIMPRINTS_ENROLMENT_KEY)
+            val registration: RegistrationSID? = registrationJson?.let {
+                Gson().fromJson(it, RegistrationSID::class.java)
+            }
 
             val hasCredential: Boolean? = data.getBooleanExtra(SIMPRINTS_HAS_CREDENTIALS, false)
 
@@ -255,7 +253,7 @@ class BiometricsClient(
                     handlePossibleDuplicates()
                 }
 
-                data.hasExtra(Constants.SIMPRINTS_REGISTRATION) -> {
+                data.hasExtra(SIMPRINTS_ENROLMENT_KEY) -> {
                     handleRegister()
                 }
 
@@ -286,8 +284,10 @@ class BiometricsClient(
                 Gson().fromJson(it, Array<IdentificationSID>::class.java)?.toList()
             }
 
-            val refusalForm: RefusalForm? =
-                data.getParcelableExtra(Constants.SIMPRINTS_REFUSAL_FORM)
+            val refusalFormJson = data.getStringExtra(Constants.SIMPRINTS_REFUSAL_FORM)
+            val refusalForm: RefusalFormSID? = refusalFormJson?.let {
+                Gson().fromJson(it, RefusalFormSID::class.java)
+            }
 
             val sessionId: String = data.getStringExtra(Constants.SIMPRINTS_SESSION_ID) ?: ""
 
@@ -642,11 +642,3 @@ class BiometricsClient(
         const val SIMPRINTS_FORK_VERSION = "forkVersion"
     }
 }
-
-fun <T : Parcelable> Intent.extractParcelableExtra(key: String, clazz: Class<T>): T? =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        getParcelableExtra(key, clazz)
-    } else {
-        @Suppress("DEPRECATION")
-        getParcelableExtra(key) as? T
-    }

--- a/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/models/sid/RefusalFormSID.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/models/sid/RefusalFormSID.kt
@@ -1,0 +1,6 @@
+package org.dhis2.data.biometrics.biometricsClient.models.sid
+
+data class RefusalFormSID(
+    val reason: String,
+    val extra: String,
+)

--- a/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/models/sid/RegistrationSID.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/models/sid/RegistrationSID.kt
@@ -1,0 +1,5 @@
+package org.dhis2.data.biometrics.biometricsClient.models.sid
+
+data class RegistrationSID(
+    val guid: String,
+)

--- a/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/models/sid/VerificationSID.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/models/sid/VerificationSID.kt
@@ -1,0 +1,14 @@
+package org.dhis2.data.biometrics.biometricsClient.models.sid
+
+data class VerificationSID(
+    val guid: String,
+    val confidence: Float,
+    val confidenceBand: String,
+)
+
+enum class ConfidenceBandSID {
+    HIGH,
+    MEDIUM,
+    LOW,
+    NONE,
+}


### PR DESCRIPTION
### 📌 References

This is an external contribution, without a reference to a ticket.

References to relevant code are in technical details below.

### ⚙️ branches

This: `bugfix-simprints/json-support-in-simprints-response`

Base: `develop-simprints`

### 🎩 What is the goal?

To fix the bug: empty biometric search results in some cases (details below) when non-empty results are returned by Simprints ID.

**Affected versions:**
* v3.2.1.1-simprints-fork-8
* v3.2.1.1-simprints-fork-7
* v3.2.1.1-simprints-fork-5
* v3.2.1.1-simprints-fork-4

**Steps** to reproduce the identification issue:
* Sign in with Simprints ID 2025.1.2 or newer and DHIS2 app of an affected version.
* In the DHIS2 app, navigate to a Program with biometrics configured.
* Click "Search / Add new person", Simprints ID will open.
* Perform an identification of a TEI for whom the biometrics were previously enrolled in the current Program.
* Observe the TEI search result list.

**Expected:**
* The search result list contains the biometrically identified TEI.

**Actual:**
* The search result list is empty

**Cause:**

When the Simprints project that is used for biometrics config does not have an "enternal credential" feature, Simprints ID expects a "versionCode" intent extra in order to return data encoded as JSON: see https://github.com/Simprints/Android-Simprints-ID/blob/v2025.4.0/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/response/LibSimprintsResponseMapper.kt#L62

The DHIS2 app processes biometric Identification results as JSON-formatted as seen at https://github.com/EyeSeeTea/dhis2-android-capture-app/blob/v3.2.1.1-simprints-fork-7/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/BiometricsClient.kt#L271, but does not include the "versionCode" extra to enable that JSON formatting while preparing intents for Simprints ID.

LibSimprints includes this extra as a constant since v2025.1.1. However, LibSimprints v2025.1.1 minSdk is higher than DHIS2 3.2.1.1-simprints-fork-8 has. So, these key and value need to be defined directly.

_A follow-up note:  also, biometric verification/enrolment & refusal forms didn't support JSON formatting of the response data - added fixes as well._

### 📝 How is it being implemented?

* `versionCode: 20250102` key-value extra is defined, explained in a comment, and added to request intents towards Simprints ID.

* Biometric verification result is updated to use JSON formatting.

### 💥 How can it be tested?

💾 Requires DB migration?
- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### 🎨 UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-