### PR TITLE
[Simprints] Revert NHIS verification flag

### DIFF
--- a/app/src/main/java/org/dhis2/data/biometrics/utils/Verification.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/utils/Verification.kt
@@ -89,7 +89,6 @@ fun getVerification(
     val verifications = getVerifications(basicPreferenceProvider)
 
     return verifications.find { it.teiUid == teiUId }
-    //return BiometricsVerification(teiUId, System.currentTimeMillis())
 }
 
 data class BiometricsVerification(val teiUid: String, val date: Long)

--- a/app/src/main/java/org/dhis2/usescases/biometrics/ui/teiDashboardBiometrics/TeiDashboardBioStatus.kt
+++ b/app/src/main/java/org/dhis2/usescases/biometrics/ui/teiDashboardBiometrics/TeiDashboardBioStatus.kt
@@ -4,17 +4,17 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowLeft
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
@@ -22,44 +22,36 @@ import androidx.compose.ui.unit.dp
 // is a copy of BiometricsStatusFlag
 @Composable
 fun TeiDashboardBioStatus(
-    model: BioStatus,
-    modifier: Modifier = Modifier
+    model: BioStatus
 ) {
-    Layout(
-        modifier = modifier,
-        content = {
-            Row(
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.background(Color(android.graphics.Color.parseColor(model.backgroundColor)))
-                    .height(40.dp)
-                    .padding(start = 16.dp)
-            ) {
-                Text(
-                    model.text.uppercase(),
-                    color = Color.White,
-                    modifier = Modifier.padding(end = 42.dp)
-                )
-            }
-            Icon(
-                imageVector = Icons.Filled.ArrowLeft,
-                contentDescription = "Arrow",
-                tint = Color.White,
-                modifier = Modifier.size(80.dp)
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(start = 16.dp)
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.background(Color(android.graphics.Color.parseColor(model.backgroundColor)))
+                .height(40.dp)
+                .padding(start = 16.dp)
+
+        ) {
+            Text(
+                model.text.uppercase(),
+                color = Color.White,
+                modifier = Modifier.padding(end = 42.dp)
             )
         }
-    ) { measurables, constraints ->
-        val textRowPlaceable = measurables[0].measure(constraints)
-        val iconPlaceable = measurables[1].measure(constraints)
-
-        layout(textRowPlaceable.width, textRowPlaceable.height) {
-            textRowPlaceable.placeRelative(0, 0)
-            val offsetPx = 46.5.dp.roundToPx()
-            val iconX = textRowPlaceable.width - offsetPx
-            val iconY = (textRowPlaceable.height - iconPlaceable.height) / 2
-            iconPlaceable.placeRelative(iconX, iconY)
-        }
+        Icon(
+            imageVector = Icons.Filled.ArrowLeft,
+            contentDescription = "Arrow",
+            tint = Color.White,
+            modifier = Modifier.size(80.dp).offset(x = (-46.5).dp, y = (0).dp)
+        )
     }
+
+
 }
 
 @Preview
@@ -72,4 +64,3 @@ fun TeiDashboardBioStatusPreview() {
         )
     )
 }
-

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.kt
@@ -354,7 +354,6 @@ class TEIDataFragment : FragmentGlobalAbstract(), TEIDataContracts.View {
                         }
                     } ?: emptyList(),
                     teiDashboardBioModel = presenter.getBiometricsModel(),
-                    teiDashboardNHISCredentialodel = presenter.getNHISCredentialStatus(),
                     isUnderAgeThreshold = isUnderAgeThreshold
                 )
             }

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataPresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataPresenter.kt
@@ -18,7 +18,6 @@ import org.dhis2.commons.bindings.canCreateEventInEnrollment
 import org.dhis2.commons.bindings.enrollment
 import org.dhis2.commons.bindings.event
 import org.dhis2.commons.bindings.program
-import org.dhis2.commons.biometrics.successLight
 import org.dhis2.commons.data.EventCreationType
 import org.dhis2.commons.data.EventViewModel
 import org.dhis2.commons.data.EventViewModelType
@@ -51,9 +50,7 @@ import org.dhis2.usescases.biometrics.getAgeInMonthsByAttributes
 import org.dhis2.usescases.biometrics.getOrgUnitAsModuleId
 import org.dhis2.usescases.biometrics.isLastVerificationValid
 import org.dhis2.usescases.biometrics.isUnderAgeThreshold
-import org.dhis2.usescases.biometrics.nhisNumberAttributeId
 import org.dhis2.usescases.biometrics.repositories.OrgUnitRepository
-import org.dhis2.usescases.biometrics.ui.teiDashboardBiometrics.BioStatus
 import org.dhis2.usescases.biometrics.ui.teiDashboardBiometrics.TeiDashboardBioModel
 import org.dhis2.usescases.biometrics.ui.teiDashboardBiometrics.TeiDashboardBioRegistrationMapper
 import org.dhis2.usescases.biometrics.ui.teiDashboardBiometrics.TeiDashboardBioVerificationMapper
@@ -682,18 +679,6 @@ class TEIDataPresenter(
 
     fun getBiometricsModel(): TeiDashboardBioModel? {
         return getBiometricsModelByDashboardModel(dashboardModel)
-    }
-
-    fun getNHISCredentialStatus(): BioStatus? {
-        val teiAttrValues = dashboardModel?.trackedEntityAttributeValues ?: listOf()
-
-        val containsNHIS =  teiAttrValues.find { it.trackedEntityAttribute() == nhisNumberAttributeId } != null
-
-        return if (containsNHIS){
-            BioStatus("NHIS Verified", successLight)
-        } else {
-            null
-        }
     }
 
     fun getBiometricsModelByDashboardModel(dashboardModel: DashboardEnrollmentModel?): TeiDashboardBioModel? {

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/ui/TeiDetailDashboard.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/ui/TeiDetailDashboard.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.unit.dp
 import org.dhis2.commons.data.EventCreationType
 import org.dhis2.usescases.biometrics.addAttrBiometricsEmojiIfRequired
 import org.dhis2.usescases.biometrics.addAttrNHISNumberEmojiIfRequired
-import org.dhis2.usescases.biometrics.ui.teiDashboardBiometrics.BioStatus
 import org.dhis2.usescases.biometrics.ui.teiDashboardBiometrics.TeiDashboardBioButton
 import org.dhis2.usescases.biometrics.ui.teiDashboardBiometrics.TeiDashboardBioModel
 import org.dhis2.usescases.biometrics.ui.teiDashboardBiometrics.TeiDashboardBioStatus
@@ -38,7 +37,6 @@ fun TeiDetailDashboard(
     modifier: Modifier = Modifier,
     isGrouped: Boolean = true,
     teiDashboardBioModel: TeiDashboardBioModel?,
-    teiDashboardNHISCredentialodel: BioStatus?,
     isUnderAgeThreshold: Boolean
 ) {
     Column(
@@ -67,25 +65,14 @@ fun TeiDetailDashboard(
         }
 
         card?.let {
-            // EyeSeeTea customization
-            Column(
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.padding(16.dp)
-            ) {
-                if (teiDashboardBioModel?.statusModel != null) {
-                    TeiDashboardBioStatus(teiDashboardBioModel.statusModel)
-                }
-
-                if (teiDashboardNHISCredentialodel != null) {
-                    TeiDashboardBioStatus(teiDashboardNHISCredentialodel)
-                }
+            // Eyeseetea customization
+            if (teiDashboardBioModel?.statusModel != null){
+                TeiDashboardBioStatus(teiDashboardBioModel.statusModel)
             }
 
-            val additionalInfoListWithBiometricsIcons =
-                addAttrBiometricsEmojiIfRequired(card.additionalInfo, isUnderAgeThreshold)
+            val additionalInfoListWithBiometricsIcons = addAttrBiometricsEmojiIfRequired(card.additionalInfo, isUnderAgeThreshold)
 
-            val additionalInfoList =
-                addAttrNHISNumberEmojiIfRequired(additionalInfoListWithBiometricsIcons).toMutableList()
+            val additionalInfoList = addAttrNHISNumberEmojiIfRequired(additionalInfoListWithBiometricsIcons).toMutableList()
 
             CardDetail(
                 title = card.title,
@@ -107,7 +94,7 @@ fun TeiDetailDashboard(
             )
         }
 
-        if (teiDashboardBioModel?.buttonModel != null) {
+        if (teiDashboardBioModel?.buttonModel != null){
             TeiDashboardBioButton(teiDashboardBioModel.buttonModel)
         }
     }

--- a/commons/src/main/java/org/dhis2/commons/biometrics/colors.kt
+++ b/commons/src/main/java/org/dhis2/commons/biometrics/colors.kt
@@ -7,7 +7,6 @@ const val defaultButtonColor = "#007acc"
 const val successButtonColor = "#FF35835D"
 const val failedButtonColor = "#C57704"
 const val declinedButtonColor = "#a6a5a4"
-const val successLight = "#80BA9E"
 
 val colorStops = arrayOf(
     0.0f to Color(0xFF009cb6),


### PR DESCRIPTION
### :pushpin: References

* **Issue:** https://app.clickup.com/t/869c1wr2q #869c1wr2q
* **Related Pull request:**

###   :gear: branches 

**app**:  Origin:feature/revert-nhis-number-flag Target: develop-simprints

**dhis2-android-SDK**:  

Origin: develop-eyeseetea

### :tophat: What is the goal?

Remove the green flag that we added for the NHIS verification. This is not useful as this is not giving any new information as compared to the NHIS number with tick mark icon. 

### :memo: How is it being implemented?

- [x] Revert nhis verification flag

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-