### PR TITLE
[Simprints] send confirm biometrics after demographic

### DIFF
--- a/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/BiometricsClient.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/BiometricsClient.kt
@@ -34,6 +34,7 @@ import timber.log.Timber
 // TODO: This constants should be in libsimprints
 private const val SIMPRINTS_HAS_CREDENTIALS = "hasCredential"
 private const val SIMPRINTS_SCANNED_CREDENTIAL = "scannedCredential"
+
 /*
 When SIMPRINTS_HAS_CREDENTIALS is false,
 Simprints ID expects a "versionCode" intent extra in order to return data encoded as JSON:
@@ -291,6 +292,11 @@ class BiometricsClient(
 
             val sessionId: String = data.getStringExtra(Constants.SIMPRINTS_SESSION_ID) ?: ""
 
+            val scannedCredentialJson = data.getStringExtra(SIMPRINTS_SCANNED_CREDENTIAL)
+            val scannedCredential: ScannedCredentialSID? = scannedCredentialJson?.let {
+                Gson().fromJson(it, ScannedCredentialSID::class.java)
+            }
+
             return if (identifications == null && refusalForm != null) {
                 IdentifyResult.BiometricsDeclined
             } else if (identifications.isNullOrEmpty()) {
@@ -298,20 +304,27 @@ class BiometricsClient(
             } else {
                 val finalIdentifications =
                     identifications.filter { it.confidence >= confidenceScoreFilter && !it.isLinkedToCredential } +
-                            identifications.filter {  it.isLinkedToCredential }
+                            identifications.filter { it.isLinkedToCredential }
 
                 if (finalIdentifications.isEmpty()) {
                     Timber.w("Identify returns data but no match with confidence score filter")
                     IdentifyResult.UserNotFound(sessionId)
                 } else {
-                    IdentifyResult.Completed(finalIdentifications.map {
-                        SimprintsIdentifiedItem(
-                            it.guid,
-                            it.confidence,
-                            it.isLinkedToCredential,
-                            it.isVerified
+                    IdentifyResult.Completed(
+                        finalIdentifications.map {
+                            SimprintsIdentifiedItem(
+                                it.guid,
+                                it.confidence,
+                                it.isLinkedToCredential,
+                                it.isVerified
+                            )
+                        },
+                        sessionId,
+                        scannedCredential = if (scannedCredential == null) null else ScannedCredential(
+                            scannedCredential.type,
+                            scannedCredential.value
                         )
-                    }, sessionId)
+                    )
                 }
             }
         } else {

--- a/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/models/IdentifyResult.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/models/IdentifyResult.kt
@@ -2,7 +2,12 @@ package org.dhis2.data.biometrics.biometricsClient.models
 
 
 sealed class IdentifyResult {
-    data class Completed(val items: List<SimprintsIdentifiedItem>, val sessionId: String) : IdentifyResult()
+    data class Completed(
+        val items: List<SimprintsIdentifiedItem>,
+        val sessionId: String,
+        val scannedCredential: ScannedCredential?
+    ) : IdentifyResult()
+
     data object BiometricsDeclined : IdentifyResult()
     data class UserNotFound(val sessionId: String) : IdentifyResult()
     data object Failure : IdentifyResult()

--- a/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/models/ScannedCredential.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/models/ScannedCredential.kt
@@ -1,0 +1,6 @@
+package org.dhis2.data.biometrics.biometricsClient.models
+
+data class ScannedCredential(
+    val type: String,
+    val value: String,
+)

--- a/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/models/SimprintsRegisteredItem.kt
+++ b/app/src/main/java/org/dhis2/data/biometrics/biometricsClient/models/SimprintsRegisteredItem.kt
@@ -6,7 +6,4 @@ data class SimprintsRegisteredItem(
     val scannedCredential: ScannedCredential?
 )
 
-data class ScannedCredential(
-    val type: String,
-    val value: String,
-)
+

--- a/app/src/main/java/org/dhis2/usescases/biometrics/ui/SequentialSearch.kt
+++ b/app/src/main/java/org/dhis2/usescases/biometrics/ui/SequentialSearch.kt
@@ -1,6 +1,7 @@
 package org.dhis2.usescases.biometrics.ui
 
 import org.dhis2.commons.biometrics.BIOMETRICS_SEARCH_PATTERN
+import org.dhis2.data.biometrics.biometricsClient.models.ScannedCredential
 import org.dhis2.data.biometrics.biometricsClient.models.SimprintsIdentifiedItem
 import org.dhis2.usescases.biometrics.biometricAttributeId
 
@@ -55,7 +56,8 @@ sealed class SequentialSearch(
         val biometricUid: String,
         val sessionId: String?,
         val isAgeNotSupported: Boolean,
-        val simprintsItems: List<SimprintsIdentifiedItem>
+        val simprintsItems: List<SimprintsIdentifiedItem>,
+        val scannedCredential: ScannedCredential?
     ) : SequentialSearch(previousSearch, nextActions)
 
     data class AttributeSearch(

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.kt
@@ -894,7 +894,7 @@ class SearchTEActivity : ActivityGlobalAbstract(), SearchTEContractsModule.View 
 
                     presenter.searchOnBiometrics(
                         completedResult.items,
-                        completedResult.sessionId, false
+                        completedResult.sessionId, false, completedResult.scannedCredential
                     )
                 } else if (result is IdentifyResult.BiometricsDeclined) {
                     Toast.makeText(
@@ -965,7 +965,7 @@ class SearchTEActivity : ActivityGlobalAbstract(), SearchTEContractsModule.View 
     private fun simulateNotFoundBiometricsSearch(sessionId: String?) {
         presenter.searchOnBiometrics(
             listOf(SimprintsIdentifiedItem(BIOMETRICS_USER_NOT_FOUND, 0f, false, false)),
-            sessionId, false
+            sessionId, false, null
         )
     }
 

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEContractsModule.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEContractsModule.java
@@ -8,6 +8,7 @@ import androidx.annotation.Nullable;
 import org.dhis2.commons.filters.FilterItem;
 import org.dhis2.commons.filters.FilterManager;
 import org.dhis2.commons.filters.Filters;
+import org.dhis2.data.biometrics.biometricsClient.models.ScannedCredential;
 import org.dhis2.data.biometrics.biometricsClient.models.SimprintsConfirmIdentityItem;
 import org.dhis2.data.biometrics.biometricsClient.models.SimprintsIdentifiedItem;
 import org.dhis2.maps.model.StageStyle;
@@ -142,7 +143,7 @@ public class SearchTEContractsModule {
 
         void trackSearchMapVisualization();
 
-        void searchOnBiometrics(List <SimprintsIdentifiedItem> simprintsIdentifiedItems, String sessionId, Boolean ageNotSupported);
+        void searchOnBiometrics(List <SimprintsIdentifiedItem> simprintsIdentifiedItems, String sessionId, Boolean ageNotSupported, ScannedCredential scannedCredential);
 
         boolean getBiometricsSearchStatus();
 

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEIViewModel.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEIViewModel.kt
@@ -197,7 +197,7 @@ class SearchTEIViewModel(
             )
         }
 
-        presenter.setBiometricListener { simprintsItems, biometricAttributeUid, items, sessionId, ageNotSupported ->
+        presenter.setBiometricListener { simprintsItems, biometricAttributeUid, items, sessionId, ageNotSupported, scannedCredential ->
             val filterValue = items.joinToString(";") { it.guid }
 
             val previousSearch = when (sequentialSearch.value) {
@@ -219,7 +219,8 @@ class SearchTEIViewModel(
                     biometricUid = filterValue,
                     previousSearch = previousSearch,
                     nextActions = nextActions,
-                    simprintsItems = simprintsItems
+                    simprintsItems = simprintsItems,
+                    scannedCredential = scannedCredential
                 )
             )
 

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
@@ -43,6 +43,7 @@ import org.dhis2.commons.schedulers.SchedulerProvider;
 import org.dhis2.commons.schedulers.SingleEventEnforcer;
 import org.dhis2.commons.schedulers.SingleEventEnforcerImpl;
 
+import org.dhis2.data.biometrics.biometricsClient.models.ScannedCredential;
 import org.dhis2.data.biometrics.biometricsClient.models.SimprintsConfirmIdentityItem;
 import org.dhis2.data.biometrics.biometricsClient.models.SimprintsIdentifiedItem;
 import org.dhis2.data.service.SyncStatusController;
@@ -64,6 +65,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import io.reactivex.Observable;
@@ -377,7 +379,7 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
 
     @Override
     public void onSearchTEIModelClick(SearchTeiModel item, SequentialSearch sequentialSearch) {
-        String TeiUid = item.getTei().uid();
+        String teiUid = item.getTei().uid();
         String enrollmentUid = item.getSelectedEnrollment() != null ?
                 item.getSelectedEnrollment().uid() :
                 null;
@@ -387,13 +389,34 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
         if (sequentialSearch instanceof SequentialSearch.BiometricsSearch) {
             view.showBiometricsSearchConfirmation(item);
             biometricsSearchStatus = false;
+        }
+        else if (previousIsBiometricsSearchAndContainCredentials (sequentialSearch)) {
+            view.showBiometricsSearchConfirmation(item);
+            biometricsSearchStatus = false;
         } else {
             if (!isOnline) {
-                openDashboard(TeiUid, enrollmentUid);
+                openDashboard(teiUid, enrollmentUid);
             } else {
-                downloadTei(TeiUid, enrollmentUid);
+                downloadTei(teiUid, enrollmentUid);
             }
         }
+    }
+
+    public boolean previousIsBiometricsSearchAndContainCredentials(SequentialSearch sequentialSearch){
+        boolean isMatchByCredentials;
+        SequentialSearch.BiometricsSearch biometricsSearch = null;
+
+        if (sequentialSearch != null && sequentialSearch.getPreviousSearch() instanceof SequentialSearch.BiometricsSearch){
+            biometricsSearch = (SequentialSearch.BiometricsSearch) sequentialSearch.getPreviousSearch();
+        }
+
+        if (biometricsSearch != null) {
+            isMatchByCredentials = biometricsSearch.getScannedCredential() != null;
+        } else {
+            isMatchByCredentials = false;
+        }
+
+        return isMatchByCredentials;
     }
 
     @Override
@@ -681,13 +704,16 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
     }
 
     @Override
-    public void searchOnBiometrics(List<SimprintsIdentifiedItem> simprintsIdentifiedItems, String sessionId, Boolean ageNotSupported) {
+    public void searchOnBiometrics(List<SimprintsIdentifiedItem> simprintsIdentifiedItems,
+                                   String sessionId, Boolean ageNotSupported,
+                                   ScannedCredential scannedCredential) {
         if (biometricsSearchListener != null) {
             this.sessionId = sessionId;
 
             biometricsSearchStatus = true;
 
-            biometricsSearchListener.onBiometricsSearch(simprintsIdentifiedItems, biometricAttributeId, simprintsIdentifiedItems, sessionId, ageNotSupported);
+            biometricsSearchListener.onBiometricsSearch(simprintsIdentifiedItems, biometricAttributeId,
+                    simprintsIdentifiedItems, sessionId, ageNotSupported,  scannedCredential);
         }
     }
 
@@ -736,7 +762,11 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
     }
 
     public interface BiometricsSearchListener {
-        void onBiometricsSearch(List<SimprintsIdentifiedItem> simprintsIdentifiedItems, String biometricAttributeUid, List<SimprintsIdentifiedItem> items, @Nullable String sessionId, Boolean ageNotSupported);
+        void onBiometricsSearch(List<SimprintsIdentifiedItem> simprintsIdentifiedItems,
+                                String biometricAttributeUid, List<SimprintsIdentifiedItem> items,
+                                @Nullable String sessionId,
+                                Boolean ageNotSupported,
+                                ScannedCredential scannedCredential);
     }
 
     private String getBiometricsAttributeValue(String teiUid) {

--- a/app/src/test/java/org/dhis2/usescases/biometrics/ui/SequentialSearchTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/biometrics/ui/SequentialSearchTest.kt
@@ -103,7 +103,8 @@ class SequentialSearchTest {
             sessionId = sessionId,
             biometricUid = biometricUid,
             isAgeNotSupported = false,
-            simprintsItems = listOf(SimprintsIdentifiedItem(biometricUid, 99.0F, false, false))
+            simprintsItems = listOf(SimprintsIdentifiedItem(biometricUid, 99.0F, false, false)),
+            scannedCredential = null
         )
         return biometricsSearch
     }
@@ -115,7 +116,8 @@ class SequentialSearchTest {
             sessionId = null,
             biometricUid = biometricUid,
             isAgeNotSupported = false,
-            simprintsItems = listOf(SimprintsIdentifiedItem(biometricUid, 99.0F, false, false))
+            simprintsItems = listOf(SimprintsIdentifiedItem(biometricUid, 99.0F, false, false)),
+            scannedCredential = null
         )
         return biometricsSearch
     }


### PR DESCRIPTION
### :pushpin: References

* **Issue:**  https://app.clickup.com/t/869c10ncd #869c10ncd
* **Related Pull request:**

###   :gear: branches 

**app**:  Origin:feature/revert-nhis-number-flag  Target: feature/revert-nhis-number-flag

**dhis2-android-SDK**:  

Origin: develop-eyeseetea

### :tophat: What is the goal?

There is a requirement we missed which we'll need to resolve before we conduct a large-scale roll out of this feature. In the following scenario:

The client hasn't already registered their NHIS card, but they are on the system with biometrics. 

Biometrics & NHIS taken
No NHIS match (as not on system)
No biometrics match (poor quality capture - which we've found to be common this week)
Demographic search & click on the correct result. 

Right now, they have the option of verifying the selected result, but (by design) this doesn't attach the credential. 

We wonder whether as part the demographic search, when the select the correct result that didn't appear during biometrics (and if it has a GUID) we trigger a 1:N confirmation callback to SID where the credential would be attached. 

### :memo: How is it being implemented?

- [x] Support send confirm identity callout from demographic search - If previous is biometrics and contains credential

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-