### PR TITLE
[SPIP] Fix portrait images from tablet gallery displayed in landscape

### DIFF
--- a/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/ui/UiActionHandlerImpl.kt
+++ b/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/ui/UiActionHandlerImpl.kt
@@ -72,7 +72,7 @@ class UiActionHandlerImpl(
             contract = GetFileResource(),
         ) { uris ->
             if (uris.isNotEmpty()) {
-                callback?.invoke(uris.firstOrNull()?.toFileOverWrite(context = context)?.path)
+                callback?.invoke(uris.firstOrNull()?.toFileOverWrite(context = context)?.rotateImage(context)?.path)
             } else {
                 onFailure?.invoke()
             }

--- a/commons/src/main/java/org/dhis2/commons/bindings/FileExtensions.kt
+++ b/commons/src/main/java/org/dhis2/commons/bindings/FileExtensions.kt
@@ -33,9 +33,9 @@ fun File.rotateImage(context: Context): File {
     val bitmap =
         BitmapFactory.decodeFile(
             this.path,
-            // EyeSeeTea - Avoid resize
+            // EyeSeeTea customization  - Avoid resize
             //BitmapFactory.Options().apply { inSampleSize = 4 },
-        ) ?: return this
+        ) ?: return this // EyeSeeTea customization - Avoid crash for non images
 
     val rotatedBitmap =
         when (orientation) {
@@ -59,7 +59,7 @@ fun File.rotateImage(context: Context): File {
 private fun rotateImage(
     source: Bitmap,
     angle: Float,
-): Bitmap? {
+): Bitmap {
     val matrix = Matrix()
     matrix.postRotate(angle)
     return Bitmap.createBitmap(source, 0, 0, source.width, source.height, matrix, true)

--- a/commons/src/main/java/org/dhis2/commons/bindings/FileExtensions.kt
+++ b/commons/src/main/java/org/dhis2/commons/bindings/FileExtensions.kt
@@ -30,14 +30,14 @@ fun File.rotateImage(context: Context): File {
     val ei = ExifInterface(this.path)
     val orientation =
         ei.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
-    var bitmap =
+    val bitmap =
         BitmapFactory.decodeFile(
             this.path,
             // EyeSeeTea - Avoid resize
             //BitmapFactory.Options().apply { inSampleSize = 4 },
-        )
+        ) ?: return this
 
-    bitmap =
+    val rotatedBitmap =
         when (orientation) {
             ExifInterface.ORIENTATION_ROTATE_90 -> rotateImage(bitmap, 90F)
             ExifInterface.ORIENTATION_ROTATE_180 -> rotateImage(bitmap, 180F)
@@ -51,7 +51,7 @@ fun File.rotateImage(context: Context): File {
             "tempFile.jpg",
         )
 
-    file.writeBitmap(bitmap, Bitmap.CompressFormat.JPEG, 100)
+    file.writeBitmap(rotatedBitmap, Bitmap.CompressFormat.JPEG, 100)
 
     return file
 }

--- a/form/src/main/java/org/dhis2/form/ui/files/ComposableRememberPickers.kt
+++ b/form/src/main/java/org/dhis2/form/ui/files/ComposableRememberPickers.kt
@@ -22,6 +22,7 @@ fun rememberFilePicker(onResult: (String) -> Unit) =
                     uris
                         .firstOrNull()
                         ?.toFileOverWrite(context = this)
+                        ?.rotateImage(this)
                         ?.path
                         ?.let(onResult)
                 },


### PR DESCRIPTION
## Problem

Portrait images selected from the **tablet camera roll** were displayed in landscape mode — both in the Android app preview and in the web app preview. Images from the phone camera roll were unaffected.

**Root cause:** Tablet cameras save JPEG files in the sensor's native landscape orientation and encode the actual (portrait) orientation as an EXIF tag. The camera capture path already called `rotateImage()` to physically rotate the pixels before upload, but the gallery picker path did not — it just byte-copied the file and passed it on with the misleading EXIF tag still intact.

Phone cameras typically bake the rotation into the pixel data before saving, so their EXIF tag is `ORIENTATION_NORMAL` and the bug does not manifest.

## Fix

Call `rotateImage()` after `toFileOverWrite()` in both gallery picker paths, mirroring what the camera capture path already does:

- `form/.../ComposableRememberPickers.kt` — `rememberFilePicker()`
- `aggregates/.../UiActionHandlerImpl.kt` — `fileLauncher`

## Side effect

Since `rotateImage()` physically rotates the pixels and saves a new JPEG (without copying the original EXIF orientation tag), the file uploaded to the server has correct pixel orientation and a neutral EXIF tag. This also fixes the web app preview, which was rendering the raw landscape pixels because it ignored the EXIF tag.

## Test plan

- [ ] Pick a portrait photo from the tablet camera roll in a form image field → preview shows portrait
- [ ] Open the image full-screen → shows portrait
- [ ] Check the same image in the web app preview → shows portrait
- [ ] Pick a portrait photo from the phone camera roll → still shows correctly (no regression)
- [ ] Take a photo directly with the camera → still shows correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)