### PR TITLE
[SPIP] fix: patch Oslo granular sync image download race (ANDROAPP-7661)

### DIFF
--- a/app/src/main/java/org/dhis2/data/service/SyncPresenterImpl.kt
+++ b/app/src/main/java/org/dhis2/data/service/SyncPresenterImpl.kt
@@ -382,7 +382,10 @@ class SyncPresenterImpl(
         return syncRepository
             .downLoadEvent(eventUid)
             .map { it as D2Progress }
-            .mergeWith(syncRepository.downloadEventFiles(eventUid))
+            // EyeSeeTea fix - granular sync race: image download can run before the event data
+            // is persisted and skip missing FileResources (Oslo ANDROAPP-7661, introduced 3.1.0).
+            // Remove when Oslo serializes data and file downloads in granular sync.
+            .concatWith(syncRepository.downloadEventFiles(eventUid))
     }
 
     override fun blockSyncGranularProgram(programUid: String): ListenableWorker.Result {
@@ -500,7 +503,10 @@ class SyncPresenterImpl(
                 syncRepository.downloadEventProgram(uid)
             }
         }?.map { it as D2Progress }
-            ?.mergeWith(syncRepository.downloadProgramFiles(uid))
+            // EyeSeeTea fix - granular sync race: image download can run before the program data
+            // is persisted and skip missing FileResources (Oslo ANDROAPP-7661, introduced 3.1.0).
+            // Remove when Oslo serializes data and file downloads in granular sync.
+            ?.concatWith(syncRepository.downloadProgramFiles(uid))
             ?: Observable.empty()
 
     override fun syncGranularTEI(uid: String): Observable<D2Progress> {
@@ -514,9 +520,10 @@ class SyncPresenterImpl(
         return syncRepository
             .downloadTei(teiUid, programUid)
             .map { it as D2Progress }
-            .mergeWith(
-                syncRepository.downloadTeiFiles(teiUid, programUid),
-            )
+            // EyeSeeTea fix - granular sync race: image download can run before the TEI data
+            // is persisted and skip missing FileResources (Oslo ANDROAPP-7661, introduced 3.1.0).
+            // Remove when Oslo serializes data and file downloads in granular sync.
+            .concatWith(syncRepository.downloadTeiFiles(teiUid, programUid))
     }
 
     override fun syncGranularDataSet(uid: String): Observable<D2Progress> =


### PR DESCRIPTION
### :pushpin: References

* **Issue:**  https://app.clickup.com/t/869dk0g0h #869dk0g0h
* **Related Pull request:** 

###   :gear: branches

**app**: Origin:  fix-spip/images_sync Target: `develop-spip`

**dhis2-android-SDK**: 1.13.1-eyeseetea-fork-2

### :tophat: What is the goal?
  
Fix race condition to sync images using granular sync from program, tei.

  - ANDROAPP-7661 (https://dhis2.atlassian.net/browse/ANDROAPP-7661) — Race condition to sync images

  ---
  ### :memo: How is it being implemented?

  Three targeted fixes, two in the app and one in the SDK:

  Change paralellel calls to secuential calls


  ### :boom: How can it be tested?
 


### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [] Yeap, here you have some screenshots



