### PR TITLE
[SPIP] fix: patch Oslo completed-event dialog always shown (ANDROAPP-7666)

### DIFF
--- a/form/src/main/java/org/dhis2/form/ui/FormViewModel.kt
+++ b/form/src/main/java/org/dhis2/form/ui/FormViewModel.kt
@@ -909,10 +909,14 @@ class FormViewModel(
 
             EventStatus.COMPLETED -> {
                 val resultAction = provideShowResultDialog(result)
+                // EyeSeeTea fix - "mark as complete?" dialog always shown for completed events
+                // (Oslo ANDROAPP-7666, introduced 3.3.1)
+                // Remove when Oslo returns FormActions.OnFinish for completed events with no issues.
                 if (resultAction?.fieldsWithIssues?.isEmpty() == true) {
                     FormActions.OnFinish
+                } else {
+                    resultAction
                 }
-                resultAction
             }
 
             EventStatus.SKIPPED -> {

--- a/form/src/test/java/org/dhis2/form/ui/FormViewModelTest.kt
+++ b/form/src/test/java/org/dhis2/form/ui/FormViewModelTest.kt
@@ -4,14 +4,19 @@ import android.content.Intent
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import org.dhis2.commons.dialogs.bottomsheet.BottomSheetDialogUiModel
 import org.dhis2.commons.viewmodel.DispatcherProvider
+import org.dhis2.form.data.EventResultDetails
 import org.dhis2.form.data.FormRepository
 import org.dhis2.form.data.GeometryController
+import org.dhis2.form.data.SuccessfulResult
 import org.dhis2.form.model.ActionType
+import org.dhis2.form.model.EventMode
 import org.dhis2.form.model.FieldUiModel
 import org.dhis2.form.model.RowAction
 import org.dhis2.form.ui.event.RecyclerViewUiEvents
@@ -19,12 +24,14 @@ import org.dhis2.form.ui.intent.FormIntent
 import org.dhis2.form.ui.provider.FormResultDialogProvider
 import org.dhis2.mobile.commons.model.CustomIntentRequestArgumentModel
 import org.hisp.dhis.android.core.common.ValueType
+import org.hisp.dhis.android.core.event.EventStatus
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -192,4 +199,53 @@ class FormViewModelTest {
 
             verify(repository).save(fieldUid, null, null)
         }
+
+    // EyeSeeTea fix - "mark as complete?" dialog always shown for completed events
+    // (Oslo ANDROAPP-7666, introduced 3.3.1)
+    // Remove this test when Oslo ships the upstream fix.
+    @Test
+    fun `Should not show result dialog for an already completed event with no issues`() =
+        runTest {
+            givenACompletedEventWithNoIssues()
+
+            viewModel.runDataIntegrityCheck()
+            advanceUntilIdle()
+
+            val action = viewModel.actionsChannel.first()
+            assertEquals(FormViewModel.FormActions.OnFinish, action)
+        }
+
+    private suspend fun givenACompletedEventWithNoIssues() {
+        val result =
+            SuccessfulResult(
+                canComplete = true,
+                onCompleteMessage = null,
+                eventResultDetails =
+                    EventResultDetails(
+                        eventStatus = EventStatus.COMPLETED,
+                        eventMode = EventMode.CHECK,
+                        validationStrategy = null,
+                    ),
+            )
+        whenever(repository.isEvent()) doReturn true
+        whenever(repository.isEventEditable()) doReturn true
+        whenever(repository.runDataIntegrityCheck(backPressed = false)) doReturn result
+        whenever(repository.composeList()) doReturn emptyList()
+        whenever(
+            resultDialogUiProvider(
+                canComplete = any(),
+                onCompleteMessage = anyOrNull(),
+                errorFields = any(),
+                emptyMandatoryFields = any(),
+                warningFields = any(),
+                eventMode = anyOrNull(),
+                eventState = anyOrNull(),
+                result = any(),
+            ),
+        ) doReturn
+            Pair(
+                BottomSheetDialogUiModel(title = "title", iconResource = 0),
+                emptyList(),
+            )
+    }
 }


### PR DESCRIPTION
### :pushpin: References

* **Issue:**  https://app.clickup.com/t/869dk0g0g #869dk0g0g
* **Related Pull request:** 

###   :gear: branches

**app**: Origin:  fix-spip/completed_event_dialog Target: `fix-spip/images_sync`

**dhis2-android-SDK**: 1.13.1-eyeseetea-fork-2

### :tophat: What is the goal?
  
Fix "Saved! Do you want to mark this form as complete?" dialog always shown for already-completed events with no issues.

  - ANDROAPP-7666 (https://dhis2.atlassian.net/browse/ANDROAPP-7666) — Completed event dialog always shown

  ---
  ### :memo: How is it being implemented?

  In `FormViewModel.kt`, the `EventStatus.COMPLETED` branch computed `FormActions.OnFinish` for events with no issues but discarded it as a dangling expression, always falling through to show the "mark as complete" dialog. Added the missing `else` so the dialog is only shown when there are still issues.

  ### :boom: How can it be tested?
 
Open any already-completed event with no field issues and exit without changes (save icon or back arrow). The form should exit without showing the "mark as complete?" dialog.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots