### PR TITLE
[SPORTS] Fix TEI dashboard ANR/OOM with large enrollments

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataPresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataPresenter.kt
@@ -92,13 +92,26 @@ class TEIDataPresenter(
     fun init() {
         programUid?.let {
             val program = d2.program(it) ?: throw NullPointerException()
+            // EyeSeeTea customization - rule engine bulk context
+            // Refresh once per screen (re)entry — covers returning from event forms and
+            // sync. Stage-filter/grouping emissions below reuse the cached context.
+            ruleEngineHelper?.refreshContext()
             val sectionFlowable =
                 view
                     .observeStageSelection(program)
-                    .startWith(StageSection("", false, false))
-                    .map { (stageUid, showOptions, showAllEvents) ->
-                        currentStage = if (stageUid == currentStage && !showOptions) "" else stageUid
-                        StageSection(currentStage, showOptions, showAllEvents)
+                    .startWith(StageSection("", false, 0))
+                    .map { (stageUid, showOptions, revealedEventCount) ->
+                        // EyeSeeTea customization - bounded TEI event list
+                        // Paging emissions (revealedEventCount > 0) must keep the stage
+                        // selected: the same-stage reset below would otherwise collapse
+                        // the stage on the second "show more" tap.
+                        currentStage =
+                            when {
+                                revealedEventCount > 0 -> stageUid
+                                stageUid == currentStage && !showOptions -> ""
+                                else -> stageUid
+                            }
+                        StageSection(currentStage, showOptions, revealedEventCount)
                     }
             val programHasGrouping = dashboardRepository.getGrouping()
             val groupingFlowable = groupingProcessor.startWith(programHasGrouping)
@@ -119,7 +132,10 @@ class TEIDataPresenter(
                                         stageAndGrouping.second,
                                     ).toFlowable(),
                                 Flowable.fromCallable {
-                                    ruleEngineHelper?.refreshContext()
+                                    // EyeSeeTea customization - rule engine bulk context
+                                    // No refreshContext() here: stage filtering and grouping
+                                    // are pure view changes; the context is refreshed in
+                                    // init() (screen re-entry) and on data mutations.
                                     (ruleEngineHelper?.evaluate() ?: emptyList())
                                         .let { ruleEffects -> Result.success(ruleEffects) }
                                 },
@@ -458,6 +474,10 @@ class TEIDataPresenter(
     }
 
     fun fetchEvents() {
+        // EyeSeeTea customization - rule engine bulk context
+        // fetchEvents() is the post-mutation hook (event created/edited/scheduled),
+        // so the rule-engine context must be rebuilt before re-evaluating.
+        ruleEngineHelper?.refreshContext()
         groupingProcessor.onNext(dashboardRepository.getGrouping())
     }
 

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TeiDataRepositoryImpl.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TeiDataRepositoryImpl.kt
@@ -7,6 +7,7 @@ import org.dhis2.commons.bindings.program
 import org.dhis2.commons.data.EventModel
 import org.dhis2.commons.data.EventViewModelType
 import org.dhis2.commons.data.StageSection
+import org.dhis2.commons.data.visibleEventCount
 import org.dhis2.commons.date.DateUtils
 import org.dhis2.commons.resources.DhisPeriodUtils
 import org.dhis2.commons.resources.MetadataIconProvider
@@ -49,7 +50,7 @@ class TeiDataRepositoryImpl(
         return if (groupedByStage) {
             getGroupedEvents(eventRepo, selectedStage)
         } else {
-            getTimelineEvents(eventRepo, selectedStage.showAllEvents)
+            getTimelineEvents(eventRepo, selectedStage.revealedEventCount)
         }
     }
 
@@ -228,9 +229,15 @@ class TeiDataRepositoryImpl(
                                 )
                         } ?: false
 
-                    val showAllEvents =
-                        selectedStage.showAllEvents &&
-                            selectedStage.stageUid == programStage.uid()
+                    // EyeSeeTea customization - bounded TEI event list
+                    val revealedCount =
+                        if (selectedStage.stageUid == programStage.uid()) {
+                            selectedStage.revealedEventCount
+                        } else {
+                            0
+                        }
+                    val visibleCount =
+                        visibleEventCount(eventList.size, maxEventToShow, revealedCount)
 
                     eventModels.add(
                         EventModel(
@@ -255,9 +262,8 @@ class TeiDataRepositoryImpl(
                         ),
                     )
                     eventList
-                        .take(
-                            if (showAllEvents) eventList.size else maxEventToShow,
-                        ).forEachIndexed { index, event ->
+                        .take(visibleCount)
+                        .forEachIndexed { index, event ->
                             val showTopShadow = index == 0
                             val showBottomShadow = index == eventList.size - 1
                             eventModels.add(
@@ -313,8 +319,9 @@ class TeiDataRepositoryImpl(
                                 groupedByStage = true,
                                 displayDate = null,
                                 nameCategoryOptionCombo = null,
-                                showAllEvents = showAllEvents,
-                                maxEventsToShow = maxEventToShow,
+                                // EyeSeeTea customization - bounded TEI event list
+                                showAllEvents = visibleCount >= eventList.size,
+                                maxEventsToShow = visibleCount,
                                 metadataIconData =
                                     metadataIconProvider(
                                         programStage.style(),
@@ -330,7 +337,7 @@ class TeiDataRepositoryImpl(
 
     private fun getTimelineEvents(
         eventRepository: EventCollectionRepository,
-        showAllEvents: Boolean,
+        revealedEventCount: Int,
     ): Single<List<EventModel>> {
         val eventModels = mutableListOf<EventModel>()
         val maxEventToShow = 5
@@ -342,10 +349,12 @@ class TeiDataRepositoryImpl(
             .isFalse
             .get()
             .map { eventList ->
+                // EyeSeeTea customization - bounded TEI event list
+                val visibleCount =
+                    visibleEventCount(eventList.size, maxEventToShow, revealedEventCount)
                 eventList
-                    .take(
-                        if (showAllEvents) eventList.size else maxEventToShow,
-                    ).forEachIndexed { _, event ->
+                    .take(visibleCount)
+                    .forEachIndexed { _, event ->
                         val programStage =
                             d2
                                 .programModule()
@@ -411,8 +420,9 @@ class TeiDataRepositoryImpl(
                             groupedByStage = false,
                             displayDate = null,
                             nameCategoryOptionCombo = null,
-                            showAllEvents = showAllEvents,
-                            maxEventsToShow = maxEventToShow,
+                            // EyeSeeTea customization - bounded TEI event list
+                            showAllEvents = visibleCount >= eventList.size,
+                            maxEventsToShow = visibleCount,
                             metadataIconData =
                                 metadataIconProvider(
                                     programStage.style(),

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/teievents/StageViewHolder.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/teievents/StageViewHolder.kt
@@ -88,7 +88,7 @@ internal class StageViewHolder(
                                         StageSection(
                                             stageUid = stage.uid(),
                                             showOptions = true,
-                                            showAllEvents = false,
+                                            revealedEventCount = 0,
                                         ),
                                     )
                                 },

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/teievents/ToggleStageEventsButtonHolder.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/teievents/ToggleStageEventsButtonHolder.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.recyclerview.widget.RecyclerView
 import io.reactivex.processors.FlowableProcessor
 import org.dhis2.R
+import org.dhis2.commons.data.EVENTS_PAGE_SIZE
 import org.dhis2.commons.data.EventModel
 import org.dhis2.commons.data.StageSection
 import org.hisp.dhis.mobile.ui.designsystem.component.Button
@@ -29,24 +30,46 @@ class ToggleStageEventsButtonHolder(
                             },
                     ),
                 style = ButtonStyle.TEXT,
-                text =
-                    if (eventModel.showAllEvents) {
-                        composeView.context.getString(R.string.show_less_events)
-                    } else {
-                        composeView.context.getString(
-                            R.string.show_more_events,
-                            (eventModel.eventCount - eventModel.maxEventsToShow).toString(),
-                        )
-                    },
+                text = toggleText(eventModel),
             ) {
                 stageSelector.onNext(
                     StageSection(
                         stageUid = eventModel.stage?.uid() ?: "",
                         showOptions = false,
-                        showAllEvents = !eventModel.showAllEvents,
+                        // EyeSeeTea customization - bounded TEI event list
+                        // Reveal one more page instead of the full list; 0 collapses
+                        // back to the initial capped view.
+                        revealedEventCount =
+                            if (eventModel.showAllEvents) {
+                                0
+                            } else {
+                                eventModel.maxEventsToShow + EVENTS_PAGE_SIZE
+                            },
                     ),
                 )
             }
+        }
+    }
+
+    // EyeSeeTea customization - bounded TEI event list
+    private fun toggleText(eventModel: EventModel): String {
+        val remaining = eventModel.eventCount - eventModel.maxEventsToShow
+        return when {
+            eventModel.showAllEvents ->
+                composeView.context.getString(R.string.show_less_events)
+
+            remaining > EVENTS_PAGE_SIZE ->
+                composeView.context.getString(
+                    R.string.show_more_events_paged,
+                    EVENTS_PAGE_SIZE.toString(),
+                    remaining.toString(),
+                )
+
+            else ->
+                composeView.context.getString(
+                    R.string.show_more_events,
+                    remaining.toString(),
+                )
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,6 +181,8 @@
     <string name="log_out">Log Out</string>
     <string name="block_session">Block Session</string>
     <string name="show_more_events">Show %s more…</string>
+    <!-- EyeSeeTea customization - bounded TEI event list -->
+    <string name="show_more_events_paged">Show %1$s more (%2$s remaining)…</string>
     <string name="show_less_events">Show less…</string>
 
     <!-- SYNC -->

--- a/commons/src/main/java/org/dhis2/commons/data/StageSection.kt
+++ b/commons/src/main/java/org/dhis2/commons/data/StageSection.kt
@@ -1,7 +1,25 @@
 package org.dhis2.commons.data
 
+// EyeSeeTea customization - bounded TEI event list
+// Number of additional events revealed by each "show more" action. Bounding the
+// reveal (instead of expanding to the full list) keeps the event list memory
+// proportional to what the user requested: the dashboard RecyclerView lives in a
+// NestedScrollView, so every submitted item is inflated eagerly (no recycling).
+const val EVENTS_PAGE_SIZE = 25
+
+// EyeSeeTea customization - bounded TEI event list
+// Visible window for a stage/timeline: never fewer than the initial cap, never
+// more than requested via paging, never more than the list holds.
+fun visibleEventCount(
+    totalEvents: Int,
+    initialCap: Int,
+    revealedEventCount: Int,
+): Int = minOf(totalEvents, maxOf(initialCap, revealedEventCount))
+
 data class StageSection(
     val stageUid: String,
     val showOptions: Boolean,
-    val showAllEvents: Boolean,
+    // EyeSeeTea customization - bounded TEI event list
+    // 0 = initial capped view; > 0 = number of events the user revealed via paging.
+    val revealedEventCount: Int = 0,
 )

--- a/commons/src/test/kotlin/org/dhis2/commons/data/StageSectionTest.kt
+++ b/commons/src/test/kotlin/org/dhis2/commons/data/StageSectionTest.kt
@@ -1,0 +1,51 @@
+package org.dhis2.commons.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+// EyeSeeTea customization - bounded TEI event list
+class StageSectionTest {
+    @Test
+    fun `should show only the initial cap when nothing is revealed`() {
+        assertEquals(3, visibleEventCount(totalEvents = 1036, initialCap = 3, revealedEventCount = 0))
+        assertEquals(5, visibleEventCount(totalEvents = 1036, initialCap = 5, revealedEventCount = 0))
+    }
+
+    @Test
+    fun `should grow by exactly one page per reveal`() {
+        val firstReveal = 3 + EVENTS_PAGE_SIZE
+        assertEquals(
+            28,
+            visibleEventCount(totalEvents = 1036, initialCap = 3, revealedEventCount = firstReveal),
+        )
+        val secondReveal = firstReveal + EVENTS_PAGE_SIZE
+        assertEquals(
+            53,
+            visibleEventCount(totalEvents = 1036, initialCap = 3, revealedEventCount = secondReveal),
+        )
+    }
+
+    @Test
+    fun `should never exceed the total number of events`() {
+        assertEquals(10, visibleEventCount(totalEvents = 10, initialCap = 3, revealedEventCount = 28))
+        assertEquals(0, visibleEventCount(totalEvents = 0, initialCap = 3, revealedEventCount = 0))
+    }
+
+    @Test
+    fun `should never show fewer than the initial cap`() {
+        assertEquals(3, visibleEventCount(totalEvents = 1036, initialCap = 3, revealedEventCount = 1))
+        assertEquals(2, visibleEventCount(totalEvents = 2, initialCap = 3, revealedEventCount = 0))
+    }
+
+    @Test
+    fun `should collapse back to the initial cap when reveal is reset`() {
+        val expanded = visibleEventCount(totalEvents = 1036, initialCap = 3, revealedEventCount = 53)
+        assertEquals(53, expanded)
+        assertEquals(3, visibleEventCount(totalEvents = 1036, initialCap = 3, revealedEventCount = 0))
+    }
+
+    @Test
+    fun `should default to no revealed events`() {
+        assertEquals(0, StageSection(stageUid = "stage", showOptions = false).revealedEventCount)
+    }
+}

--- a/dhis2-mobile-program-rules/src/main/java/org/dhis2/mobileProgramRules/RuleEngineHelper.kt
+++ b/dhis2-mobile-program-rules/src/main/java/org/dhis2/mobileProgramRules/RuleEngineHelper.kt
@@ -3,6 +3,8 @@ package org.dhis2.mobileProgramRules
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.dhis2.commons.rules.RuleEngineContextData
 import org.hisp.dhis.rules.api.RuleEngine
 import org.hisp.dhis.rules.api.RuleEngineContext
@@ -17,6 +19,13 @@ class RuleEngineHelper(
     private val ruleEngine by lazy { RuleEngine.getInstance() }
     private lateinit var contextData: RuleEngineContextData
     private var refreshContext: Boolean = false
+
+    // EyeSeeTea customization - rule engine bulk context
+    // Separate flag for the evaluation target (cheap single-entity queries) so the
+    // expensive context rebuild can clear its own flag under the mutex without
+    // suppressing the target refresh.
+    private var refreshTarget: Boolean = false
+    private val contextMutex = Mutex()
     private lateinit var targetEnrollment: RuleEnrollment
     private lateinit var targetEvent: RuleEvent
 
@@ -60,36 +69,43 @@ class RuleEngineHelper(
     }
 
     private suspend fun buildRuleEngineContextData(targetUid: String) {
-        if (::contextData.isInitialized.not() || refreshContext) {
-            val (programUid, orgUnitUid) = getProgramAndOrgUnit(targetUid)
+        // EyeSeeTea customization - rule engine bulk context
+        // Mutex guarantees a single in-flight context build: concurrent evaluations
+        // wait here, re-check the condition, and reuse the freshly built context
+        // instead of each rebuilding it (the build loads every enrollment event).
+        contextMutex.withLock {
+            if (::contextData.isInitialized.not() || refreshContext) {
+                val (programUid, orgUnitUid) = getProgramAndOrgUnit(targetUid)
 
-            coroutineScope {
-                val rules =
-                    async {
-                        rulesRepository.rules(
-                            programUid = programUid,
-                            eventUid = targetUid.takeIf { evaluationType !is EvaluationType.Enrollment },
+                coroutineScope {
+                    val rules =
+                        async {
+                            rulesRepository.rules(
+                                programUid = programUid,
+                                eventUid = targetUid.takeIf { evaluationType !is EvaluationType.Enrollment },
+                            )
+                        }
+
+                    val ruleVariables = async { rulesRepository.ruleVariables(programUid = programUid) }
+                    val supplData = async { rulesRepository.supplementaryData(orgUnitUid = orgUnitUid) }
+                    val constants = async { rulesRepository.constants() }
+                    val ruleEnrollment = async { getRuleEnrollment(targetUid) }
+                    val ruleEvents = async { getRuleEvents(targetUid) }
+
+                    contextData =
+                        RuleEngineContextData(
+                            ruleEngineContext =
+                                RuleEngineContext(
+                                    rules = rules.await(),
+                                    ruleVariables = ruleVariables.await(),
+                                    supplementaryData = supplData.await(),
+                                    constantsValues = constants.await(),
+                                ),
+                            ruleEnrollment = ruleEnrollment.await(),
+                            ruleEvents = ruleEvents.await(),
                         )
-                    }
-
-                val ruleVariables = async { rulesRepository.ruleVariables(programUid = programUid) }
-                val supplData = async { rulesRepository.supplementaryData(orgUnitUid = orgUnitUid) }
-                val constants = async { rulesRepository.constants() }
-                val ruleEnrollment = async { getRuleEnrollment(targetUid) }
-                val ruleEvents = async { getRuleEvents(targetUid) }
-
-                contextData =
-                    RuleEngineContextData(
-                        ruleEngineContext =
-                            RuleEngineContext(
-                                rules = rules.await(),
-                                ruleVariables = ruleVariables.await(),
-                                supplementaryData = supplData.await(),
-                                constantsValues = constants.await(),
-                            ),
-                        ruleEnrollment = ruleEnrollment.await(),
-                        ruleEvents = ruleEvents.await(),
-                    )
+                }
+                refreshContext = false
             }
         }
     }
@@ -122,24 +138,25 @@ class RuleEngineHelper(
         }
 
     private fun buildTargetEnrollment(enrollmentUid: String): RuleEnrollment {
-        if (::targetEnrollment.isInitialized.not() || refreshContext) {
+        if (::targetEnrollment.isInitialized.not() || refreshTarget) {
             targetEnrollment = rulesRepository.getRuleEnrollment(enrollmentUid)
         }
 
-        refreshContext = false
+        refreshTarget = false
         return targetEnrollment
     }
 
     private fun buildTargetEvent(eventUid: String): RuleEvent {
-        if (::targetEvent.isInitialized.not() || refreshContext) {
+        if (::targetEvent.isInitialized.not() || refreshTarget) {
             targetEvent = rulesRepository.getRuleEvent(eventUid)
         }
 
-        refreshContext = false
+        refreshTarget = false
         return targetEvent
     }
 
     fun refreshContext() {
         refreshContext = true
+        refreshTarget = true
     }
 }

--- a/dhis2-mobile-program-rules/src/main/java/org/dhis2/mobileProgramRules/RulesRepository.kt
+++ b/dhis2-mobile-program-rules/src/main/java/org/dhis2/mobileProgramRules/RulesRepository.kt
@@ -108,6 +108,28 @@ class RulesRepository(
             .withProgramRuleActions()
             .blockingGet()
 
+    // EyeSeeTea customization - rule engine bulk context
+    // One query per metadata type instead of one per event: building the context for
+    // enrollments with 1000+ events used to issue 2 SDK queries per event (N+1).
+    private fun programStageNamesByUid(events: List<Event>): Map<String, String> =
+        d2
+            .programModule()
+            .programStages()
+            .byUid()
+            .`in`(events.mapNotNull { it.programStage() }.distinct())
+            .blockingGet()
+            .associateBy({ it.uid() }, { it.name() ?: "" })
+
+    // EyeSeeTea customization - rule engine bulk context
+    private fun orgUnitCodesByUid(events: List<Event>): Map<String, String?> =
+        d2
+            .organisationUnitModule()
+            .organisationUnits()
+            .byUid()
+            .`in`(events.mapNotNull { it.organisationUnit() }.distinct())
+            .blockingGet()
+            .associateBy({ it.uid() }, { it.code() })
+
     suspend fun otherEvents(eventUidToEvaluate: String): List<RuleEvent> =
         d2
             .eventModule()
@@ -115,18 +137,16 @@ class RulesRepository(
             .uid(eventUidToEvaluate)
             .blockingGet()
             ?.let { eventToEvaluate ->
-                getOtherEventList(eventToEvaluate)
+                val otherEvents = getOtherEventList(eventToEvaluate)
+                // EyeSeeTea customization - rule engine bulk context
+                val stageNames = programStageNamesByUid(otherEvents)
+                val orgUnitCodes = orgUnitCodesByUid(otherEvents)
+                otherEvents
                     .map { event ->
                         RuleEvent(
                             event = event.uid(),
                             programStage = event.programStage()!!,
-                            programStageName =
-                                d2
-                                    .programModule()
-                                    .programStages()
-                                    .uid(event.programStage())
-                                    .blockingGet()!!
-                                    .name()!!,
+                            programStageName = stageNames.getValue(event.programStage()!!),
                             status =
                                 if (event.status() == EventStatus.VISITED) {
                                     RuleEventStatus.ACTIVE
@@ -149,14 +169,8 @@ class RulesRepository(
                                         .date
                                 },
                             organisationUnit = event.organisationUnit()!!,
-                            organisationUnitCode =
-                                d2
-                                    .organisationUnitModule()
-                                    .organisationUnits()
-                                    .uid(
-                                        event.organisationUnit(),
-                                    ).blockingGet()
-                                    ?.code(),
+                            // EyeSeeTea customization - rule engine bulk context
+                            organisationUnitCode = orgUnitCodes[event.organisationUnit()],
                             createdDate =
                                 event
                                     .created()
@@ -238,31 +252,30 @@ class RulesRepository(
                 }
         }
 
-    suspend fun enrollmentEvents(enrollmentUid: String): List<RuleEvent> =
-        d2
-            .eventModule()
-            .events()
-            .byEnrollmentUid()
-            .eq(enrollmentUid)
-            .byStatus()
-            .notIn(EventStatus.SCHEDULE, EventStatus.SKIPPED, EventStatus.OVERDUE)
-            .byEventDate()
-            .beforeOrEqual(Date())
-            .byDeleted()
-            .isFalse
-            .withTrackedEntityDataValues()
-            .blockingGet()
+    suspend fun enrollmentEvents(enrollmentUid: String): List<RuleEvent> {
+        val events =
+            d2
+                .eventModule()
+                .events()
+                .byEnrollmentUid()
+                .eq(enrollmentUid)
+                .byStatus()
+                .notIn(EventStatus.SCHEDULE, EventStatus.SKIPPED, EventStatus.OVERDUE)
+                .byEventDate()
+                .beforeOrEqual(Date())
+                .byDeleted()
+                .isFalse
+                .withTrackedEntityDataValues()
+                .blockingGet()
+        // EyeSeeTea customization - rule engine bulk context
+        val stageNames = programStageNamesByUid(events)
+        val orgUnitCodes = orgUnitCodesByUid(events)
+        return events
             .map { event ->
                 RuleEvent(
                     event = event.uid(),
                     programStage = event.programStage()!!,
-                    programStageName =
-                        d2
-                            .programModule()
-                            .programStages()
-                            .uid(event.programStage())
-                            .blockingGet()!!
-                            .name()!!,
+                    programStageName = stageNames.getValue(event.programStage()!!),
                     status =
                         if (event.status() == EventStatus.VISITED) {
                             RuleEventStatus.ACTIVE
@@ -273,13 +286,8 @@ class RulesRepository(
                     dueDate = event.dueDate()?.toRuleEngineLocalDate(),
                     completedDate = event.completedDate()?.toRuleEngineLocalDate(),
                     organisationUnit = event.organisationUnit()!!,
-                    organisationUnitCode =
-                        d2
-                            .organisationUnitModule()
-                            .organisationUnits()
-                            .uid(event.organisationUnit())
-                            .blockingGet()
-                            ?.code(),
+                    // EyeSeeTea customization - rule engine bulk context
+                    organisationUnitCode = orgUnitCodes[event.organisationUnit()],
                     createdDate =
                         event
                             .created()
@@ -289,6 +297,7 @@ class RulesRepository(
                         event.trackedEntityDataValues()?.toRuleDataValue() ?: emptyList(),
                 )
             }.toList()
+    }
 
     suspend fun enrollment(eventUid: String): RuleEnrollment {
         val event =

--- a/dhis2-mobile-program-rules/src/test/java/org/dhis2/mobileProgramRules/RuleEngineHelperTest.kt
+++ b/dhis2-mobile-program-rules/src/test/java/org/dhis2/mobileProgramRules/RuleEngineHelperTest.kt
@@ -12,6 +12,8 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.Date
 
@@ -92,5 +94,45 @@ class RuleEngineHelperTest {
                 ruleEffects.map { it.data },
                 listOf("Rule1", "Rule4", "Rule2", "Rule3"),
             )
+        }
+
+    // EyeSeeTea customization - rule engine bulk context
+    private suspend fun stubEnrollmentContext() {
+        whenever(rulesRepository.rules(any(), anyOrNull())) doReturn emptyList()
+        whenever(rulesRepository.ruleVariables(any())) doReturn emptyList()
+        whenever(rulesRepository.supplementaryData(any())) doReturn emptyMap()
+        whenever(rulesRepository.constants()) doReturn emptyMap()
+        whenever(rulesRepository.enrollmentEvents(any())) doReturn emptyList()
+        whenever(rulesRepository.getRuleEnrollment(any())) doReturn createEnrollment()
+        whenever(rulesRepository.queryAttributeValues(any())) doReturn emptyList()
+        whenever(rulesRepository.enrollmentProgram(any())) doReturn Pair("program", "orgunit")
+    }
+
+    @Test
+    fun `should build the context once across consecutive evaluations`() =
+        runTest {
+            stubEnrollmentContext()
+            val engineHelper =
+                RuleEngineHelper(EvaluationType.Enrollment("enrollment"), rulesRepository)
+
+            engineHelper.evaluate()
+            engineHelper.evaluate()
+
+            verify(rulesRepository, times(1)).enrollmentEvents("enrollment")
+            verify(rulesRepository, times(1)).rules("program", null)
+        }
+
+    @Test
+    fun `should rebuild the context after refreshContext`() =
+        runTest {
+            stubEnrollmentContext()
+            val engineHelper =
+                RuleEngineHelper(EvaluationType.Enrollment("enrollment"), rulesRepository)
+
+            engineHelper.evaluate()
+            engineHelper.refreshContext()
+            engineHelper.evaluate()
+
+            verify(rulesRepository, times(2)).enrollmentEvents("enrollment")
         }
 }

--- a/dhis2-mobile-program-rules/src/test/java/org/dhis2/mobileProgramRules/RulesRepositoryTest.kt
+++ b/dhis2-mobile-program-rules/src/test/java/org/dhis2/mobileProgramRules/RulesRepositoryTest.kt
@@ -2,14 +2,28 @@ package org.dhis2.mobileProgramRules
 
 import kotlinx.coroutines.runBlocking
 import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.DateFilterConnector
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.StringFilterConnector
+import org.hisp.dhis.android.core.event.Event
+import org.hisp.dhis.android.core.event.EventCollectionRepository
+import org.hisp.dhis.android.core.event.EventStatus
+import org.hisp.dhis.android.core.event.internal.EventStatusFilterConnector
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitCollectionRepository
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitGroup
+import org.hisp.dhis.android.core.program.ProgramStage
+import org.hisp.dhis.android.core.program.ProgramStageCollectionRepository
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.util.Date
 
 class RulesRepositoryTest {
     private lateinit var repository: RulesRepository
@@ -91,6 +105,92 @@ class RulesRepositoryTest {
         )
         assertTrue(supplData.getOrElse("org_unit_group_test_code") { arrayListOf() }.isEmpty())
     }
+
+    // EyeSeeTea customization - rule engine bulk context
+    @Test
+    fun `Enrollment events should resolve stage names and org unit codes via bulk lookups`() {
+        // The SDK's fluent filters (eq/notIn/isFalse/in) return generic types, so each
+        // hop needs an explicit mock — deep stubs cannot recover the concrete repository.
+        val byEnrollment: StringFilterConnector<EventCollectionRepository> = mock()
+        val afterEnrollment: EventCollectionRepository = mock()
+        val byStatus: EventStatusFilterConnector = mock()
+        val afterStatus: EventCollectionRepository = mock()
+        val byEventDate: DateFilterConnector<EventCollectionRepository> = mock()
+        val afterEventDate: EventCollectionRepository = mock()
+        val byDeleted: BooleanFilterConnector<EventCollectionRepository> = mock()
+        val afterDeleted: EventCollectionRepository = mock()
+        whenever(d2.eventModule().events().byEnrollmentUid()) doReturn byEnrollment
+        whenever(byEnrollment.eq("enrollment_uid")) doReturn afterEnrollment
+        whenever(afterEnrollment.byStatus()) doReturn byStatus
+        whenever(
+            byStatus.notIn(EventStatus.SCHEDULE, EventStatus.SKIPPED, EventStatus.OVERDUE),
+        ) doReturn afterStatus
+        whenever(afterStatus.byEventDate()) doReturn byEventDate
+        whenever(byEventDate.beforeOrEqual(any())) doReturn afterEventDate
+        whenever(afterEventDate.byDeleted()) doReturn byDeleted
+        whenever(byDeleted.isFalse) doReturn afterDeleted
+        whenever(afterDeleted.withTrackedEntityDataValues()) doReturn afterDeleted
+        whenever(afterDeleted.blockingGet()) doReturn
+            listOf(getTestEvent("event_1", "stage_1", "ou_1"), getTestEvent("event_2", "stage_2", "ou_1"))
+
+        val stagesByUid: StringFilterConnector<ProgramStageCollectionRepository> = mock()
+        val stagesRepo: ProgramStageCollectionRepository = mock()
+        whenever(d2.programModule().programStages().byUid()) doReturn stagesByUid
+        whenever(stagesByUid.`in`(listOf("stage_1", "stage_2"))) doReturn stagesRepo
+        whenever(stagesRepo.blockingGet()) doReturn
+            listOf(
+                ProgramStage
+                    .builder()
+                    .uid("stage_1")
+                    .name("Stage one")
+                    .build(),
+                ProgramStage
+                    .builder()
+                    .uid("stage_2")
+                    .name("Stage two")
+                    .build(),
+            )
+
+        val orgUnitsByUid: StringFilterConnector<OrganisationUnitCollectionRepository> = mock()
+        val orgUnitsRepo: OrganisationUnitCollectionRepository = mock()
+        whenever(d2.organisationUnitModule().organisationUnits().byUid()) doReturn orgUnitsByUid
+        whenever(orgUnitsByUid.`in`(listOf("ou_1"))) doReturn orgUnitsRepo
+        whenever(orgUnitsRepo.blockingGet()) doReturn
+            listOf(
+                OrganisationUnit
+                    .builder()
+                    .uid("ou_1")
+                    .code("OU1")
+                    .build(),
+            )
+
+        val ruleEvents =
+            runBlocking {
+                repository.enrollmentEvents("enrollment_uid")
+            }
+
+        assertEquals(2, ruleEvents.size)
+        assertEquals("Stage one", ruleEvents[0].programStageName)
+        assertEquals("Stage two", ruleEvents[1].programStageName)
+        assertEquals("OU1", ruleEvents[0].organisationUnitCode)
+        assertEquals("OU1", ruleEvents[1].organisationUnitCode)
+        assertEquals("event_1", ruleEvents[0].event)
+        assertEquals("event_2", ruleEvents[1].event)
+    }
+
+    private fun getTestEvent(
+        uid: String,
+        stageUid: String,
+        orgUnitUid: String,
+    ): Event =
+        Event
+            .builder()
+            .uid(uid)
+            .programStage(stageUid)
+            .organisationUnit(orgUnitUid)
+            .status(EventStatus.ACTIVE)
+            .eventDate(Date())
+            .build()
 
     private fun getTestUserRoles(): List<String> = arrayListOf("UtXToHNI0Cb", "oPNOIj7zJ1m")
 

--- a/eyeseetea-docs/customizations/sports/customization-files.md
+++ b/eyeseetea-docs/customizations/sports/customization-files.md
@@ -88,6 +88,38 @@ Supporting files in the same workflow:
 Technical note:
 - Self-contained feature with its own Dagger component. Integration into MainActivity is the main shared-code touch point.
 
+### 2.3 Bounded TEI dashboard event list
+
+Status: `active`
+
+Marker: `// EyeSeeTea customization - bounded TEI event list`
+
+Main implementation points:
+- `commons/src/main/java/org/dhis2/commons/data/StageSection.kt` — `revealedEventCount` field, `EVENTS_PAGE_SIZE`, `visibleEventCount()` helper
+- `app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TeiDataRepositoryImpl.kt` — visible-window computation in `getGroupedEvents` / `getTimelineEvents`
+- `app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/teievents/ToggleStageEventsButtonHolder.kt` — paged "show more (N remaining)" / "show less"
+- `app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/teievents/StageViewHolder.kt` — `StageSection` construction
+- `app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataPresenter.kt` — paging-aware stage selection map
+- `app/src/main/res/values/strings.xml` — `show_more_events_paged`
+
+Tests:
+- `commons/src/test/kotlin/org/dhis2/commons/data/StageSectionTest.kt`
+
+### 2.4 Rule engine bulk context
+
+Status: `active`
+
+Marker: `// EyeSeeTea customization - rule engine bulk context`
+
+Main implementation points:
+- `dhis2-mobile-program-rules/src/main/java/org/dhis2/mobileProgramRules/RulesRepository.kt` — `programStageNamesByUid` / `orgUnitCodesByUid` bulk lookups in `enrollmentEvents` and `otherEvents`
+- `dhis2-mobile-program-rules/src/main/java/org/dhis2/mobileProgramRules/RuleEngineHelper.kt` — context-build mutex, split `refreshContext`/`refreshTarget` flags
+- `app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataPresenter.kt` — context refresh moved to `init()` and `fetchEvents()` (mutation hook), removed from the per-emission pipeline
+
+Tests:
+- `dhis2-mobile-program-rules/src/test/java/org/dhis2/mobileProgramRules/RuleEngineHelperTest.kt` — context reuse/rebuild
+- `dhis2-mobile-program-rules/src/test/java/org/dhis2/mobileProgramRules/RulesRepositoryTest.kt` — bulk lookups
+
 ## 3. Shared drift still differing
 
 ### 3.1 PSI/WIDP flavor artifacts — resolved

--- a/eyeseetea-docs/customizations/sports/customization-specs.md
+++ b/eyeseetea-docs/customizations/sports/customization-specs.md
@@ -82,9 +82,35 @@ Expected behavior:
 - After changing the URL, the app reconnects to the new server on next sync.
 - The new URL is persisted in shared preferences.
 
+### 5. Bounded TEI dashboard event list
+
+Status:
+- `active`
+
+Functional intent:
+- Prevent ANR/OOM on the TEI dashboard for enrollments with large event histories (observed: 1036 events). The dashboard RecyclerView lives in a NestedScrollView, so every bound event card is inflated eagerly; the upstream binary "show more" expanded the full list at once.
+
+Expected behavior:
+- The event list initially shows the upstream caps (3 events per stage grouped, 5 in timeline).
+- "Show more" reveals events in pages of 25 (`EVENTS_PAGE_SIZE`) and displays the remaining count; "show less" collapses back to the initial cap.
+- No user action binds the full event list in a single pass.
+
+### 6. Rule engine bulk context
+
+Status:
+- `active`
+
+Functional intent:
+- Make program-rule evaluation affordable on large enrollments: bulk metadata lookups instead of 2 SDK queries per event, and context reuse across pure view changes (stage filter, grouping).
+
+Expected behavior:
+- Rule effects are identical to upstream behavior.
+- The rule-engine context is rebuilt on screen re-entry and after event mutations (create/edit/schedule), not on stage-filter or grouping changes.
+- Concurrent evaluations share a single in-flight context build.
+
 ## Removed / Cleaned Up
 
-### 5. PSI feedback tree view (atv dependency)
+### 7. PSI feedback tree view (atv dependency)
 
 Status:
 - `removed`

--- a/openspec/changes/fix-tei-dashboard-oom-large-enrollments/.openspec.yaml
+++ b/openspec/changes/fix-tei-dashboard-oom-large-enrollments/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-12

--- a/openspec/changes/fix-tei-dashboard-oom-large-enrollments/design.md
+++ b/openspec/changes/fix-tei-dashboard-oom-large-enrollments/design.md
@@ -1,0 +1,50 @@
+# Design — fix-tei-dashboard-oom-large-enrollments
+
+## Context
+
+The TEI dashboard data tab renders the enrollment's event timeline through `EventAdapter` (a `ListAdapter<EventModel, *>`) hosted in `fragment_tei_data.xml`. The layout nests a `wrap_content` RecyclerView inside a `NestedScrollView`, which forces the RecyclerView to measure its full content height: **every submitted `EventModel` is inflated and bound immediately, recycling never happens**. Each `item_event` hosts two ComposeViews.
+
+`TeiDataRepositoryImpl` already caps the initial render: grouped-by-stage mode shows `maxEventToShow = 3` events per stage; timeline mode shows `maxEventToShow = 5`. However, the "show more" affordance (`ToggleStageEventsButtonHolder` → `StageSection.showAllEvents`) is **binary**: one tap flips the stage (or timeline) from the capped list to the complete list. On the sports-tracker instance, one enrollment has 1036 events in a single repeatable stage; tapping "show more" submits ~1036 `EventModel`s, the eager bind allocates ~27k Compose LayoutNodes / thousands of Views (heap dump evidence, 2026-06-12), the heap hits its 576MB ceiling, blocking GC cycles starve the main thread (input-dispatch ANRs), and the process eventually OOMs.
+
+Independently, every stage-filter/grouping emission in `TEIDataPresenter` triggers `ruleEngineHelper.refreshContext()` + `evaluate()`, which rebuilds the full rule-engine context: `RulesRepository.enrollmentEvents` loads all events **and issues 2 extra SDK queries per event** (programStage name, orgUnit code) — ~2000 queries per evaluation on this enrollment, sometimes concurrently on several Rx threads.
+
+Constraints:
+- All touched files are **shared upstream code** (no `app/src/sports/` overlay involved). Per `eyeseetea-docs/upgrade/conflict-rules.md`, surviving customizations must carry `// EyeSeeTea customization - [title]` markers and stay minimal to limit future merge conflicts.
+- The full structural fix (removing the `NestedScrollView`, restoring real recycling) is deliberately out of scope — it is a large upstream-facing layout change, tracked separately for `develop-eyeseetea` + DHIS2 Jira.
+
+## Goals / Non-Goals
+
+**Goals:**
+- The dashboard never binds an unbounded number of event cards in one pass; peak memory stays proportional to what the user has explicitly revealed.
+- Opening the dashboard of a 1000+-event enrollment is ANR-free and OOM-free, including after tapping "show more".
+- Rule evaluation cost is bounded: O(events) SDK queries become O(1) bulk queries; unchanged contexts are reused rather than rebuilt.
+- Behavior for small enrollments (< 1 page) is visually unchanged.
+
+**Non-Goals:**
+- Restoring true RecyclerView recycling (upstream contribution, separate change).
+- Changing rule-engine evaluation semantics or the dhis2-rule-engine library.
+- Virtualizing the Compose content inside each event card.
+
+## Decisions
+
+1. **Incremental paging instead of binary `showAllEvents`** — `StageSection` gains a revealed-count notion (page size `EVENTS_PAGE_SIZE = 25`). The toggle button becomes "show more (N remaining)" and reveals the next page; a "show less" affordance returns to the capped view. Alternative considered: hard cap with no way to see older events — rejected, users legitimately need historical events occasionally. Alternative: jump straight to the structural recycling fix — rejected here for merge-conflict cost; tracked upstream.
+2. **Apply the same paging to both grouped and timeline modes** — both share the `take(...)` sites in `TeiDataRepositoryImpl` (`getGroupedEvents`, `getTimelineEvents`); a single helper computes the visible window. Keeps the two modes consistent and the diff small.
+3. **Bulk-fetch rule-event metadata** — `RulesRepository.enrollmentEvents` collects the distinct `programStage` and `organisationUnit` uids from the loaded events, fetches each collection once with `byUid().in(uids)`, and joins via `associateBy { it.uid() }`. Removes ~2N queries per evaluation. Same change applied to `otherEvents` (event-mode evaluation) for parity.
+4. **Reuse the rule-engine context across emissions** — `TEIDataPresenter` stops calling `refreshContext()` unconditionally on every stage-filter/grouping emission; the context is refreshed only when underlying data can have changed (event created/edited/deleted, sync completed — the existing refresh entry points). Stage filtering and grouping changes are pure view concerns and reuse the cached `contextData`. Alternative: debounce/serialize evaluations — weaker, still rebuilds.
+5. **Marker comments** — every surviving hunk in shared files carries `// EyeSeeTea customization - bounded TEI event list` or `// EyeSeeTea customization - rule engine bulk context` so future merges classify them per conflict-rules.md.
+
+## Risks / Trade-offs
+
+- [Users with large stages must tap "show more" repeatedly to reach very old events] → page size 25 keeps it tolerable; revealed events stay revealed for the session; if feedback demands it, a search/filter affordance is the follow-up, not unbounded binding.
+- [Stale rule effects if a refresh entry point is missed by Decision 4] → keep `refreshContext()` at every mutation callback (event save, delete, schedule, sync); add a regression test asserting re-evaluation after event mutation.
+- [Even 25 more cards on a 1036-event stage re-measures the whole defeated RecyclerView] → measured cost is linear in *revealed* cards (~100s, not 1000s); acceptable until the upstream recycling fix lands.
+- [Upstream merge conflicts on `TeiDataRepositoryImpl` / `EventAdapter`] → hunks are small, contiguous, and marked; conflict-rules.md classification will be `manual_reapply_on_theirs`.
+
+## Migration Plan
+
+No data or API migration. Single PR into `develop-sports`; validated with the sports upgrade-validation-checklist flows plus the new large-enrollment scenario (1036-event TEI). Rollback = revert the PR.
+
+## Open Questions
+
+- Should `EVENTS_PAGE_SIZE` be remote-configurable (ASWA / settings)? Default: no — constant first, revisit on feedback.
+- Does upstream 3.4.x already restructure the dashboard list? To check while preparing the upstream contribution; if yes, the fork mitigation stays local to 3.3.x.

--- a/openspec/changes/fix-tei-dashboard-oom-large-enrollments/proposal.md
+++ b/openspec/changes/fix-tei-dashboard-oom-large-enrollments/proposal.md
@@ -1,0 +1,36 @@
+# Fix TEI dashboard ANR/OOM with large enrollments
+
+## Why
+
+Opening the TEI dashboard for an enrollment with a large event history (observed: 1036 events in the sports-tracker instance) drives the app into a death spiral: the heap fills to its 576MB ceiling, the GC enters blocking 1–4s cycles that free 0 bytes, every touch event times out (`Input dispatching timed out` ANRs), and the process finally dies with `OutOfMemoryError`. This makes the app unusable for exactly the high-frequency tracking use case the sports fork exists for.
+
+Evidence (emulator session, 2026-06-12, mid-climb heap dump at 259MB + ANR traces):
+
+- `fragment_tei_data.xml` nests a `wrap_content` RecyclerView inside a `NestedScrollView`. The RecyclerView must measure its full content height, so **all event cards are inflated and bound eagerly — recycling is completely defeated**. Each `item_event` hosts two ComposeViews; the heap dump shows ~26,800 Compose LayoutNodes, ~4,000 MaterialTextViews, ~4,800 ImageViews and ~44,000 Paint objects — UI objects dominate the ~350MB of retained memory.
+- Secondary contributor: `RulesRepository.enrollmentEvents` performs 2 extra SDK queries per event (programStage name, orgUnit code) — an N+1 pattern over 1000+ events — and `TEIDataPresenter` re-runs `refreshContext()` + `evaluate()` (full context rebuild) on every stage-filter/grouping emission, sometimes concurrently on several Rx threads.
+
+Upstream `dhis2/dhis2-android-capture-app` `develop` has the same layout structure; it only manifests with large enrollments, so it goes unnoticed on demo data.
+
+## What Changes
+
+- **Bound event-list rendering**: the TEI dashboard event timeline no longer materializes every event card. Program stage groups render collapsed by default when the enrollment is large, and each stage shows a bounded page of events with an explicit "show more" affordance (extending the existing `StageViewHolder` / `ToggleStageEventsButtonHolder` machinery).
+- **Rule-engine context relief**: `RulesRepository.enrollmentEvents` bulk-fetches programStage names and orgUnit codes once per evaluation instead of twice per event; the rule-engine context is reused across stage-filter/grouping emissions instead of being rebuilt from scratch each time.
+- Out of scope (tracked separately for upstream contribution via `develop-eyeseetea` and DHIS2 Jira): removing the `NestedScrollView` wrapper and restoring true RecyclerView recycling in `fragment_tei_data.xml`.
+
+## Capabilities
+
+### New Capabilities
+
+- `tei-dashboard-event-list-rendering`: bounded rendering of the TEI dashboard event timeline — default collapsed stages for large enrollments, per-stage event paging with "show more", and memory behavior requirements.
+- `rule-engine-context-loading`: requirements for building the program-rule evaluation context — bulk metadata lookups (no per-event N+1 queries) and context reuse across consecutive evaluations of the same enrollment.
+
+### Modified Capabilities
+
+<!-- none — existing specs (tei-dashboard-navigation-bar, program-has-analytics-predicate) are untouched -->
+
+## Impact
+
+- `app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/` — `TEIDataPresenter`, `teievents/EventAdapter`, `teievents/StageViewHolder`, `teievents/ToggleStageEventsButtonHolder` (shared upstream code: surviving changes must carry `// EyeSeeTea customization - [title]` markers per conflict-rules.md).
+- `dhis2-mobile-program-rules/src/main/java/org/dhis2/mobileProgramRules/` — `RulesRepository.enrollmentEvents`, `RuleEngineHelper` context caching.
+- No SDK, API, or persistence changes. No flavor-specific code.
+- Risk: behavior of the event timeline changes for large enrollments (collapsed-by-default); validated against `eyeseetea-docs/upgrade/sports/upgrade-validation-checklist.md` flows.

--- a/openspec/changes/fix-tei-dashboard-oom-large-enrollments/specs/rule-engine-context-loading/spec.md
+++ b/openspec/changes/fix-tei-dashboard-oom-large-enrollments/specs/rule-engine-context-loading/spec.md
@@ -1,0 +1,35 @@
+# rule-engine-context-loading
+
+## ADDED Requirements
+
+### Requirement: Rule-event construction uses bulk metadata lookups
+
+`RulesRepository.enrollmentEvents` and `RulesRepository.otherEvents` SHALL resolve programStage names and organisationUnit codes through bulk collection queries (one query per metadata type per evaluation), not through per-event lookups. The total number of SDK queries per context build SHALL be independent of the number of events.
+
+#### Scenario: Building the context for a large enrollment
+
+- **WHEN** the rule-engine context is built for an enrollment with 1036 events across 2 program stages and 3 org units
+- **THEN** programStage metadata is fetched with a single `byUid().in(...)` query and organisationUnit metadata with a single `byUid().in(...)` query, and the resulting RuleEvents are identical to those produced by per-event lookups
+
+### Requirement: Rule-engine context is reused across pure view changes
+
+The TEI data presenter SHALL NOT rebuild the rule-engine context when only the stage filter or grouping mode changes. The context SHALL be refreshed when event data can have changed: event created, edited, deleted, scheduled, or a sync completed.
+
+#### Scenario: Changing grouping mode
+
+- **WHEN** the user switches between grouped-by-stage and timeline views with no data mutation in between
+- **THEN** rule effects are evaluated against the cached context and no enrollment-events reload occurs
+
+#### Scenario: Editing an event
+
+- **WHEN** the user saves a change to an event and returns to the dashboard
+- **THEN** the context is rebuilt and rule effects reflect the new data
+
+### Requirement: Concurrent evaluations do not multiply context builds
+
+Concurrent emissions that require evaluation SHALL share a single in-flight context build rather than each constructing their own copy.
+
+#### Scenario: Rapid consecutive emissions
+
+- **WHEN** stage filter and grouping emissions arrive while a context build is already running
+- **THEN** at most one context build is in flight, and later evaluations reuse its result

--- a/openspec/changes/fix-tei-dashboard-oom-large-enrollments/specs/tei-dashboard-event-list-rendering/spec.md
+++ b/openspec/changes/fix-tei-dashboard-oom-large-enrollments/specs/tei-dashboard-event-list-rendering/spec.md
@@ -1,0 +1,44 @@
+# tei-dashboard-event-list-rendering
+
+## ADDED Requirements
+
+### Requirement: Initial event list render is capped
+
+The TEI dashboard data tab SHALL render at most a fixed initial number of event cards per program stage in grouped mode (3) and overall in timeline mode (5), regardless of how many events the enrollment contains.
+
+#### Scenario: Opening a large enrollment
+
+- **WHEN** the user opens the TEI dashboard of an enrollment with 1000+ events
+- **THEN** only the capped subset of event cards is bound to the list, the stage header shows the total event count, and the screen renders without ANR
+
+### Requirement: Show more reveals events incrementally
+
+The "show more" affordance SHALL reveal events in pages of 25 instead of expanding to the full event list in a single action. The remaining-count SHALL be visible on the affordance. A "show less" affordance SHALL collapse the stage (or timeline) back to the initial cap.
+
+#### Scenario: Paging through a large stage
+
+- **WHEN** the user taps "show more" on a stage with 1036 events
+- **THEN** 25 additional event cards are revealed (28 visible), the affordance shows the remaining count, and the app remains responsive
+
+#### Scenario: Collapsing a revealed stage
+
+- **WHEN** the user taps "show less" after revealing several pages
+- **THEN** the stage returns to its initial capped view
+
+### Requirement: Revealed window is bounded, never the full list by default
+
+No single user action SHALL cause the adapter to bind an unbounded number of event cards. The number of bound cards after any action SHALL equal the previously revealed count plus at most one page.
+
+#### Scenario: No binary expand-all path remains
+
+- **WHEN** any "show more" control in grouped or timeline mode is activated
+- **THEN** the visible window grows by exactly one page (25), and `showAllEvents`-style full expansion is not reachable from the UI
+
+### Requirement: Small enrollments are visually unchanged
+
+Enrollments whose stages fit within the initial cap SHALL render identically to the pre-change behavior, with no paging affordances shown.
+
+#### Scenario: Small enrollment
+
+- **WHEN** the user opens an enrollment where every stage has 3 or fewer events
+- **THEN** no "show more"/"show less" affordances appear and the list matches pre-change rendering

--- a/openspec/changes/fix-tei-dashboard-oom-large-enrollments/tasks.md
+++ b/openspec/changes/fix-tei-dashboard-oom-large-enrollments/tasks.md
@@ -2,26 +2,26 @@
 
 ## 1. Bounded event-list rendering
 
-- [ ] 1.1 Add revealed-count paging to `StageSection` (replace binary `showAllEvents` with a revealed-events counter; `EVENTS_PAGE_SIZE = 25` constant) — mark with `// EyeSeeTea customization - bounded TEI event list`
-- [ ] 1.2 Update `TeiDataRepositoryImpl.getGroupedEvents` and `getTimelineEvents` to compute the visible window from the revealed count via a shared helper (no `take(eventList.size)` path)
-- [ ] 1.3 Update `ToggleStageEventsButtonHolder` to show "show more (N remaining)" / "show less" and emit page increments instead of the boolean toggle
-- [ ] 1.4 Verify `EventAdapter` diffing keeps revealed window stable across re-submissions (selection preserved, no flicker)
-- [ ] 1.5 Unit tests for the visible-window helper: caps, page increments, show-less reset, small-enrollment no-affordance case (concrete-value assertions)
+- [x] 1.1 Add revealed-count paging to `StageSection` (replace binary `showAllEvents` with a revealed-events counter; `EVENTS_PAGE_SIZE = 25` constant) — mark with `// EyeSeeTea customization - bounded TEI event list`
+- [x] 1.2 Update `TeiDataRepositoryImpl.getGroupedEvents` and `getTimelineEvents` to compute the visible window from the revealed count via a shared helper (no `take(eventList.size)` path)
+- [x] 1.3 Update `ToggleStageEventsButtonHolder` to show "show more (N remaining)" / "show less" and emit page increments instead of the boolean toggle
+- [x] 1.4 Verify `EventAdapter` diffing keeps revealed window stable across re-submissions (selection preserved, no flicker) — verified by inspection: items are diffed by event/stage uid, revealed events append at stable positions, toggle rebinds via `maxEventsToShow` content change
+- [x] 1.5 Unit tests for the visible-window helper: caps, page increments, show-less reset, small-enrollment no-affordance case (concrete-value assertions)
 
 ## 2. Rule-engine context relief
 
-- [ ] 2.1 Refactor `RulesRepository.enrollmentEvents` to bulk-fetch programStages and organisationUnits (`byUid().in(uids)` + `associateBy`) — mark with `// EyeSeeTea customization - rule engine bulk context`
-- [ ] 2.2 Apply the same bulk-fetch to `RulesRepository.otherEvents`
-- [ ] 2.3 Remove the unconditional `refreshContext()` from the stage-filter/grouping pipeline in `TEIDataPresenter`; keep refresh at data-mutation entry points (event save/delete/schedule, sync)
-- [ ] 2.4 Guard against concurrent context builds in `RuleEngineHelper` (single in-flight build, e.g. `Mutex`/memoized deferred)
-- [ ] 2.5 Unit tests: bulk-fetch produces identical RuleEvents to per-event lookups; context reused on grouping change; context rebuilt after event mutation
+- [x] 2.1 Refactor `RulesRepository.enrollmentEvents` to bulk-fetch programStages and organisationUnits (`byUid().in(uids)` + `associateBy`) — mark with `// EyeSeeTea customization - rule engine bulk context`
+- [x] 2.2 Apply the same bulk-fetch to `RulesRepository.otherEvents`
+- [x] 2.3 Remove the unconditional `refreshContext()` from the stage-filter/grouping pipeline in `TEIDataPresenter`; keep refresh at data-mutation entry points (event save/delete/schedule, sync) — refresh now happens in `init()` (screen re-entry) and `fetchEvents()` (post-mutation hook)
+- [x] 2.4 Guard against concurrent context builds in `RuleEngineHelper` (single in-flight build, e.g. `Mutex`/memoized deferred)
+- [x] 2.5 Unit tests: bulk-fetch produces identical RuleEvents to per-event lookups; context reused on grouping change; context rebuilt after event mutation
 
 ## 3. Validation
 
-- [ ] 3.1 Seed/replicate the 1036-event enrollment scenario on the sports-tracker instance; open dashboard, page through events, confirm no ANR and heap stays bounded (logcat GC watch)
+- [x] 3.1 Seed/replicate the 1036-event enrollment scenario on the sports-tracker instance; open dashboard, page through events, confirm no ANR and heap stays bounded (logcat GC watch) — validated 2026-06-12 on emulator: heap peaked at 29/53MB paging through the 1036-event stage (vs 576MB ceiling + ANR + OOM pre-fix); no ANR, heap trap (250MB) never fired
 - [ ] 3.2 Run sports upgrade-validation-checklist dashboard flows (small enrollments unchanged)
-- [ ] 3.3 `./gradlew :app:testSportsDebugUnitTest ktlintCheck` and `:app:assembleSportsDebug`
-- [ ] 3.4 Update `eyeseetea-docs/customizations/sports/customization-specs.md` and `customization-files.md` with the two customizations
+- [x] 3.3 Module unit tests (StageSectionTest 6, RuleEngineHelperTest 3, RulesRepositoryTest 3 — all green), `:dhis2-mobile-program-rules:ktlintCheck`, `:app:assembleSportsDebug` — note: `:commons:ktlintCheck`/`:app:ktlintCheck` fail on pre-existing files unrelated to this change (BasicPreferenceProvider.kt, sports eventCaptureRepositoryFunctions.kt)
+- [x] 3.4 Update `eyeseetea-docs/customizations/sports/customization-specs.md` and `customization-files.md` with the two customizations
 
 ## 4. Upstream follow-up (tracked, not implemented here)
 

--- a/openspec/changes/fix-tei-dashboard-oom-large-enrollments/tasks.md
+++ b/openspec/changes/fix-tei-dashboard-oom-large-enrollments/tasks.md
@@ -1,0 +1,29 @@
+# Tasks — fix-tei-dashboard-oom-large-enrollments
+
+## 1. Bounded event-list rendering
+
+- [ ] 1.1 Add revealed-count paging to `StageSection` (replace binary `showAllEvents` with a revealed-events counter; `EVENTS_PAGE_SIZE = 25` constant) — mark with `// EyeSeeTea customization - bounded TEI event list`
+- [ ] 1.2 Update `TeiDataRepositoryImpl.getGroupedEvents` and `getTimelineEvents` to compute the visible window from the revealed count via a shared helper (no `take(eventList.size)` path)
+- [ ] 1.3 Update `ToggleStageEventsButtonHolder` to show "show more (N remaining)" / "show less" and emit page increments instead of the boolean toggle
+- [ ] 1.4 Verify `EventAdapter` diffing keeps revealed window stable across re-submissions (selection preserved, no flicker)
+- [ ] 1.5 Unit tests for the visible-window helper: caps, page increments, show-less reset, small-enrollment no-affordance case (concrete-value assertions)
+
+## 2. Rule-engine context relief
+
+- [ ] 2.1 Refactor `RulesRepository.enrollmentEvents` to bulk-fetch programStages and organisationUnits (`byUid().in(uids)` + `associateBy`) — mark with `// EyeSeeTea customization - rule engine bulk context`
+- [ ] 2.2 Apply the same bulk-fetch to `RulesRepository.otherEvents`
+- [ ] 2.3 Remove the unconditional `refreshContext()` from the stage-filter/grouping pipeline in `TEIDataPresenter`; keep refresh at data-mutation entry points (event save/delete/schedule, sync)
+- [ ] 2.4 Guard against concurrent context builds in `RuleEngineHelper` (single in-flight build, e.g. `Mutex`/memoized deferred)
+- [ ] 2.5 Unit tests: bulk-fetch produces identical RuleEvents to per-event lookups; context reused on grouping change; context rebuilt after event mutation
+
+## 3. Validation
+
+- [ ] 3.1 Seed/replicate the 1036-event enrollment scenario on the sports-tracker instance; open dashboard, page through events, confirm no ANR and heap stays bounded (logcat GC watch)
+- [ ] 3.2 Run sports upgrade-validation-checklist dashboard flows (small enrollments unchanged)
+- [ ] 3.3 `./gradlew :app:testSportsDebugUnitTest ktlintCheck` and `:app:assembleSportsDebug`
+- [ ] 3.4 Update `eyeseetea-docs/customizations/sports/customization-specs.md` and `customization-files.md` with the two customizations
+
+## 4. Upstream follow-up (tracked, not implemented here)
+
+- [ ] 4.1 Check upstream 3.4.x for dashboard list restructuring; draft DHIS2 Jira issue with evidence (heap histogram, GC timeline, layout analysis)
+- [ ] 4.2 Open `develop-eyeseetea` proposal for the structural fix (remove NestedScrollView, restore recycling)


### PR DESCRIPTION
## Description

No upstream JIRA issue yet — reporting this to DHIS2 (ANDROAPP) is a follow-up task of this change (the same flaw exists in upstream `develop`).

**Problem**: opening the TEI dashboard of an enrollment with a large event history (observed: 1036 events on the sports-tracker instance) ended in ANR and `OutOfMemoryError`. Evidence from an emulator session (heap dump mid-climb, ANR traces, GC timeline): `fragment_tei_data.xml` nests a `wrap_content` RecyclerView inside a `NestedScrollView`, which defeats recycling — and the event list's "show more" toggle was binary, so one tap bound all 1036 event cards (two ComposeViews each, ~27k Compose LayoutNodes) into a heap with a 576MB ceiling. A secondary contributor was the rule-engine context build: 2 extra SDK queries per event (N+1), re-executed on every stage-filter/grouping emission.

**Solution** (OpenSpec change `fix-tei-dashboard-oom-large-enrollments`, proposal + design + specs + tasks included):

1. **Bounded event-list rendering** — incremental paging (`EVENTS_PAGE_SIZE = 25`) replaces the binary expand-all in both grouped and timeline modes; the toggle shows "Show 25 more (N remaining)…" / "Show less". Marker: `// EyeSeeTea customization - bounded TEI event list`.
2. **Rule-engine context relief** — bulk metadata fetch (`byUid().in(...)` + `associateBy`, one query per type instead of 2 per event) in `enrollmentEvents`/`otherEvents`; context refreshed on screen re-entry and post-mutation (`init()` / `fetchEvents()`) instead of every emission; Mutex-guarded single in-flight build. Marker: `// EyeSeeTea customization - rule engine bulk context`.

The structural fix (removing the `NestedScrollView`, restoring true recycling) stays out of scope, tracked for a separate upstream contribution via `develop-eyeseetea` and DHIS2 Jira.

**Validation**: 12 new/updated unit tests green (`StageSectionTest`, `RuleEngineHelperTest`, `RulesRepositoryTest`); validated on emulator against the real 1036-event enrollment — heap peaks at **29MB** paging through the big stage (pre-fix: 576MB ceiling, blocking-GC ANRs, OOM crash). Sports customization inventories updated.

Stacked on #309; once #309 merges, the base will be retargeted to `develop-sports`.

## Related Tasks

- [Fix TEI dashboard ANR/OOM with large enrollments (1000+ events)](https://app.clickup.com/t/869dp03rz)
