### PR TITLE
[Simprints] Fix: blank RecyclerView after biometric search (stale program results race)

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.kt
@@ -30,7 +30,6 @@ import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import dhis2.org.analytics.charts.ui.GroupAnalyticsFragment.Companion.forProgram
 import io.reactivex.functions.Consumer
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.dhis2.App
 import org.dhis2.R
@@ -837,8 +836,6 @@ class SearchTEActivity :
         }
 
     override fun launchBiometricsIdentify(moduleId: String?, userOrgUnits: List<String>) {
-        // EyeSeeTea customization - Hide RecyclerView before launching biometric app
-        viewModel.notifyBiometricAppLaunching()
         BiometricsClientFactory.get(this).identify(this, moduleId, userOrgUnits)
     }
 
@@ -951,11 +948,6 @@ class SearchTEActivity :
                     ).show()
 
                     simulateNotFoundBiometricsSearch(null, null)
-                }
-
-                lifecycleScope.launch {
-                    delay(200)
-                    viewModel.resetBiometricAppLaunching()
                 }
             }
 

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.kt
@@ -836,6 +836,7 @@ class SearchTEActivity :
         }
 
     override fun launchBiometricsIdentify(moduleId: String?, userOrgUnits: List<String>) {
+        viewModel.notifyBiometricAppLaunching()
         BiometricsClientFactory.get(this).identify(this, moduleId, userOrgUnits)
     }
 

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEIViewModel.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEIViewModel.kt
@@ -188,10 +188,6 @@ class SearchTEIViewModel(
     private val _isDataLoaded = MutableLiveData<Boolean?>(false)
     val isDataLoaded: MutableLiveData<Boolean?> = _isDataLoaded
 
-    // EyeSeeTea customization - Notify when biometric app is about to be launched to hide RecyclerView
-    private val _biometricAppLaunching = MutableLiveData<Boolean>(false)
-    val biometricAppLaunching: LiveData<Boolean> = _biometricAppLaunching
-
     init {
         viewModelScope.launch(dispatchers.io()) {
             createButtonScrollVisibility.postValue(
@@ -1399,14 +1395,5 @@ class SearchTEIViewModel(
             }
         }
     }
-
-    // EyeSeeTea customization - Method to notify that biometric app is about to be launched
-    fun notifyBiometricAppLaunching() {
-        _biometricAppLaunching.postValue(true)
-    }
-
-    // EyeSeeTea customization - Reset biometric app launching flag when search completes
-    fun resetBiometricAppLaunching() {
-        _biometricAppLaunching.postValue(false)
-    }
 }
+

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEIViewModel.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEIViewModel.kt
@@ -153,6 +153,9 @@ class SearchTEIViewModel(
 
     var searchParametersUiState by mutableStateOf(SearchParametersUiState())
 
+    private val _biometricAppLaunching = MutableLiveData<Boolean>(false)
+    val biometricAppLaunching: LiveData<Boolean> = _biometricAppLaunching
+
     var uiState by mutableStateOf(SearchParametersUiState())
 
     var mapManager: MapManager? = null
@@ -1394,6 +1397,10 @@ class SearchTEIViewModel(
                 presenter.sendAutomaticBiometricsConfirmIdentity(dhisSearchItem)
             }
         }
+    }
+
+    fun notifyBiometricAppLaunching() {
+        _biometricAppLaunching.postValue(true)
     }
 }
 

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/listView/SearchTEList.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/listView/SearchTEList.kt
@@ -7,21 +7,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.compose.ui.res.stringResource
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.activityViewModels
@@ -34,7 +26,6 @@ import androidx.paging.LoadState
 import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.dhis2.bindings.dp
@@ -56,7 +47,6 @@ import org.dhis2.usescases.searchTrackEntity.SearchTeiViewModelFactory
 import org.dhis2.usescases.searchTrackEntity.adapters.SearchTeiLiveAdapter
 import org.dhis2.usescases.searchTrackEntity.ui.CreateNewButton
 import org.dhis2.usescases.searchTrackEntity.ui.FullSearchButtonAndWorkingList
-import org.dhis2.usescases.searchTrackEntity.ui.LoadingContent
 import org.dhis2.usescases.searchTrackEntity.ui.mapper.TEICardMapper
 import org.dhis2.utils.isLandscape
 import timber.log.Timber
@@ -177,8 +167,6 @@ class SearchTEList : FragmentGlobalAbstract() {
                 //EyeSeeTea customization
                 configureCreateButton(createButton)
                 configureSequentialSearchNextAction(nextActions)
-                configureBiometricsLoader(biometricsLoader)
-                configureRecyclerVisibility()
             }.also {
                 observeNewData()
             }.root
@@ -404,30 +392,12 @@ class SearchTEList : FragmentGlobalAbstract() {
         }
 
         liveAdapter.addLoadStateListener { state ->
-            /* EyeSeTea customization - Show loader when loading new results
-                if (state.append == LoadState.Loading) {
+            if (state.append == LoadState.Loading) {
                 displayResult(
                     listOf(SearchResult(SearchResult.SearchResultType.LOADING)),
                 )
             } else {
                 displayResult(null)
-             */
-            when {
-                state.refresh == LoadState.Loading -> {
-                    displayResult(
-                        listOf(SearchResult(SearchResult.SearchResultType.LOADING)),
-                    )
-                }
-
-                state.append == LoadState.Loading -> {
-                    displayResult(
-                        listOf(SearchResult(SearchResult.SearchResultType.LOADING)),
-                    )
-                }
-
-                else -> {
-                    displayResult(null)
-                }
             }
         }
 
@@ -601,83 +571,5 @@ class SearchTEList : FragmentGlobalAbstract() {
         currentLastClickedTeiUid = item.tei.uid()
 
         viewModel.onSearchTeiModelClick(item)
-    }
-
-    private fun configureBiometricsLoader(composeView: ComposeView) {
-        composeView.apply {
-            setViewCompositionStrategy(
-                ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed,
-            )
-            setContent {
-                val sequentialSearch by viewModel.sequentialSearch.observeAsState()
-                val biometricAppLaunching by viewModel.biometricAppLaunching.observeAsState(false)
-                val isBiometricSearch = sequentialSearch is SequentialSearch.BiometricsSearch
-                var isLoading by remember { mutableStateOf(false) }
-
-                LaunchedEffect(isBiometricSearch) {
-                    if (isBiometricSearch) {
-                        liveAdapter.loadStateFlow.collect { loadState ->
-                            isLoading = loadState.refresh is LoadState.Loading
-                        }
-                    } else {
-                        isLoading = false
-                    }
-                }
-
-                if (biometricAppLaunching || (isBiometricSearch && isLoading)) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .fillMaxHeight(),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        LoadingContent(
-                            loadingDescription = stringResource(org.dhis2.R.string.search_loading_more)
-                        )
-                    }
-                }
-            }
-        }
-    }
-
-    private fun configureRecyclerVisibility() {
-        viewModel.biometricAppLaunching.observe(viewLifecycleOwner) { isLaunching ->
-            if (isLaunching) {
-                recycler.visibility = View.GONE
-            }
-        }
-
-        viewModel.sequentialSearch.observe(viewLifecycleOwner) { sequentialSearch ->
-            val isBiometricSearch = sequentialSearch is SequentialSearch.BiometricsSearch
-
-            if (isBiometricSearch) {
-                recycler.visibility = View.GONE
-            } else {
-                lifecycleScope.launch {
-                    delay(200)
-                    recycler.visibility = View.VISIBLE
-                }
-            }
-        }
-
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                liveAdapter.loadStateFlow.collect { loadState ->
-                    val isBiometricSearch =
-                        viewModel.sequentialSearch.value is SequentialSearch.BiometricsSearch
-                    val biometricAppLaunching = viewModel.biometricAppLaunching.value == true
-
-                    val isLoading = loadState.refresh is LoadState.Loading
-
-                    if (isBiometricSearch) {
-                        if (biometricAppLaunching || isLoading) {
-                            recycler.visibility = View.GONE
-                        } else {
-                            recycler.visibility = View.VISIBLE
-                        }
-                    }
-                }
-            }
-        }
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/listView/SearchTEList.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/listView/SearchTEList.kt
@@ -392,6 +392,10 @@ class SearchTEList : FragmentGlobalAbstract() {
         }
 
         liveAdapter.addLoadStateListener { state ->
+            val adapterDetached = !listAdapter.adapters.contains(liveAdapter)
+            if (adapterDetached && state.refresh is LoadState.NotLoading) {
+                restoreProgramAdapterAfterRefresh()
+            }
             if (state.append == LoadState.Loading) {
                 displayResult(
                     listOf(SearchResult(SearchResult.SearchResultType.LOADING)),
@@ -436,12 +440,18 @@ class SearchTEList : FragmentGlobalAbstract() {
         displayResult(null)
     }
 
+    private var lastSearchPagingData: Any? = null
+
     private fun initData() {
         displayLoadingData()
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.searchPagingData.collect { data ->
+                    if (data !== lastSearchPagingData) {
+                        lastSearchPagingData = data
+                        hideStaleProgramResults()
+                    }
                     liveAdapter.addOnPagesUpdatedListener {
                         onInitDataLoaded()
 
@@ -534,6 +544,16 @@ class SearchTEList : FragmentGlobalAbstract() {
         recycler.post {
             resultAdapter.submitList(result)
         }
+    }
+
+    private fun hideStaleProgramResults() {
+        listAdapter.removeAdapter(liveAdapter)
+        initLoading(listOf(SearchResult(SearchResult.SearchResultType.LOADING)))
+    }
+
+    private fun restoreProgramAdapterAfterRefresh() {
+        listAdapter.addAdapter(1, liveAdapter)
+        initLoading(null)
     }
 
     @ExperimentalAnimationApi

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/listView/SearchTEList.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/listView/SearchTEList.kt
@@ -374,6 +374,12 @@ class SearchTEList : FragmentGlobalAbstract() {
             restoreAdapters()
         }
 
+        viewModel.biometricAppLaunching.observe(viewLifecycleOwner) { launching ->
+            if (launching) {
+                hideStaleProgramResults()
+            }
+        }
+
         viewModel.dataResult.observe(viewLifecycleOwner) {
             initLoading(emptyList())
             it.firstOrNull()?.let { searchResult ->

--- a/app/src/main/res/layout/fragment_search_list.xml
+++ b/app/src/main/res/layout/fragment_search_list.xml
@@ -56,11 +56,5 @@
             app:layout_anchor="@id/scrollView"
             app:layout_anchorGravity="bottom|center_horizontal" />
 
-        <!-- EyeSeeTea customization - Centered loader shown when RecyclerView is hidden during biometric search -->
-        <androidx.compose.ui.platform.ComposeView
-            android:id="@+id/biometricsLoader"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" />
-
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>


### PR DESCRIPTION
### :pushpin: References

* **Issue:** https://app.clickup.com/t/4528615/869dw6v6n

###   :gear: branches

**app**: Origin: `fix-simprints/bug_reading_from_simprints_by_minified` (#312)  Target: `fix-simprints/biometrics-blank-screen-recycler-race`

**dhis2-android-SDK**:

Origin: (no SDK changes)

### :tophat: What is the goal?

Client-reported bug (Ghana deployment): after a Simprints biometric identify search returns to the TEI search screen, the results list sometimes stays blank even though results exist server-side. Reported to happen consistently when the device is offline, across multiple Samsung Galaxy Tab A9/A8 devices.

Fix a race condition that can leave `SearchTEList`'s RecyclerView showing stale/blank results after a biometric search via Simprints, instead of the new results.

### :memo: How is it being implemented?

The original EyeSeeTea customization hid/showed the RecyclerView (`View.GONE`/`VISIBLE`) around the biometric search using a dedicated `biometricAppLaunching` LiveData plus an artificial `delay(200)` before resetting it. This raced against Jetpack Paging's `loadStateFlow`/`searchPagingData` re-emission on lifecycle re-subscription (e.g. if the fragment drops below `STARTED` while Simprints is in the foreground), and could leave the recycler in an inconsistent state with no rescue mechanism.

This PR:
1. Reverts the original EyeSeeTea recycler-hide-during-biometric-search customization (`configureBiometricsLoader`/`configureRecyclerVisibility`, the `biometricAppLaunching` LiveData with its reset/delay, and the related ComposeView loader).
2. Ports as-is the structural fix Oslo already reviewed and merged upstream for the equivalent stale-program-results bug (`ANDROAPP-7647`, commits `4c6522860` / `d787d890f`): replace manual `recycler.visibility` toggling with structural adapter detach/attach (`listAdapter.removeAdapter(liveAdapter)` / `addAdapter(1, liveAdapter)`), and a single `addLoadStateListener` as the source of truth that re-attaches the adapter once `state.refresh is LoadState.NotLoading`. Guarded with `lastSearchPagingData` so re-subscribing to the `searchPagingData` StateFlow after a lifecycle drop doesn't re-trigger the hide for an already-handled emission.
3. Re-adds the Simprints-specific hook: `hideStaleProgramResults()` is now called proactively as soon as the biometric app is about to launch (`launchBiometricsIdentify()` → `viewModel.notifyBiometricAppLaunching()` → `SearchTEList` observer), instead of waiting for `searchPagingData` to emit a new object. This closes the original race window without needing any artificial delay or separate reset call — restoration is handled entirely by the existing `addLoadStateListener` once `NotLoading` is reached.

### :boom: How can it be tested?

1. Perform a Simprints biometric identify search (with or without NHIS card scan/skip) and confirm the results list is shown correctly on return, both online and offline.
2. Repeat searches back-to-back and confirm no stale/blank results appear.
3. Navigate away (e.g. to TEI dashboard) and back during/after a biometric search and confirm results remain consistent.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-